### PR TITLE
Use LINK_COMMAND to link test binaries

### DIFF
--- a/config/rules/test_make_rules.mak
+++ b/config/rules/test_make_rules.mak
@@ -128,6 +128,6 @@ $(TEMPS:%.cc=%.o) : %.o : %.cc
 
 
 % : %.o $(PROJECT_LIBDEPS)
-	$(CXX) $(CXXFLAGS) $(TEMPLATES) -o $@ $@.o $($(@:=_LIBS)) $(LIBS)
+	$(LINK_COMMAND) -o $@ $@.o $($(@:=_LIBS)) $(LIBS)
 
 


### PR DESCRIPTION
LINK_COMMAND is how speech-tools links, so let's use it for linking.