### PR TITLE
Fix mismatch in ch_wave "-pc" argument

### DIFF
--- a/main/ch_wave_main.cc
+++ b/main/ch_wave_main.cc
@@ -203,7 +203,7 @@ int main (int argc, char *argv[])
 		wave_info(sigload);
 	    else if (al.present("-pc"))
 	    {
-		if ((al.val("-pc") == "longest") &&
+		if ((downcase(al.val("-pc")) == "longest") &&
 		    (sig.num_samples() < sigload.num_samples()))
 		    sig.resize(sigload.num_samples());
 		else /* "first" or sig is longer */


### PR DESCRIPTION
The documentation for ch_wave specifies "-pc LONGEST" while the code checks for "-pc longest".

This patch ensures both longest and LONGEST work as expected.

Patch ported from Debian.

The documentation:

https://github.com/festvox/speech_tools/blob/42bb85333e8be915e21475039cbf9e42f4410a09/main/ch_wave_main.cc#L153-L156

The code:

https://github.com/festvox/speech_tools/blob/42bb85333e8be915e21475039cbf9e42f4410a09/main/ch_wave_main.cc#L206

This patch just performs a "downcase" on the given "-pc" argument