### PR TITLE
Use c++ standard headers in c++ code

### DIFF
--- a/base_class/EST_TSimpleMatrix.cc
+++ b/base_class/EST_TSimpleMatrix.cc
@@ -45,7 +45,9 @@
 #include <fstream>
 #include <iostream>
 #include "EST_cutils.h"
-#include <string.h>
+#include <cstring>
+
+using std::memcpy;
 
 template<class T> 
 void EST_TSimpleMatrix<T>::copy_data(const EST_TSimpleMatrix<T> &a)

--- a/base_class/EST_TSimpleVector.cc
+++ b/base_class/EST_TSimpleVector.cc
@@ -44,7 +44,11 @@
 #include "EST_matrix_support.h"
 #include <fstream>
 #include "EST_cutils.h"
-#include <string.h>
+#include <cstring>
+
+using std::memset;
+using std::memcpy;
+
 
 template<class T> void EST_TSimpleVector<T>::copy(const EST_TSimpleVector<T> &a)
 {

--- a/include/EST_dynamic_model.h
+++ b/include/EST_dynamic_model.h
@@ -38,8 +38,8 @@
 /*=======================================================================*/
 
 #include <cstdlib>
-#include <stdio.h>
-#include <fstream.h>
+#include <cstdio>
+#include <fstream>
 #include "EST.h"
 #include "EST_model_types.h"
 


### PR DESCRIPTION
Very simple fix, using c++ standard headers instead of the C variants.