### PR TITLE
wagon + openmp + shared library requires passing -fopenmp when linking

### DIFF
--- a/config/compilers/gcc_defaults.mak
+++ b/config/compilers/gcc_defaults.mak
@@ -83,7 +83,7 @@ SHARED_LINKFLAGS =
 ifndef GCC_MAKE_SHARED_LIB
 # Older versions of gcc might have required -fno-shared-data
 #    MAKE_SHARED_LIB = $(CXX) -shared -fno-shared-data -o XXX
-    MAKE_SHARED_LIB = $(CXX) -shared -o XXX
+    MAKE_SHARED_LIB = $(CXX) $(OMP_OPTS) -shared -o XXX
 else
     MAKE_SHARED_LIB = $(GCC_MAKE_SHARED_LIB)
 endif


### PR DESCRIPTION
This patch adds OpenMP flags to the command used to link the shared library.

OpenMP is used by the wagon tool since speech_tools 2.5. It is used in the
libestools shared library, so the library has to be linked with the OpenMP
flags.

(As the others, this is a patch from Debian)