### PR TITLE
Check fread for errors

### DIFF
--- a/include/EST_Token.h
+++ b/include/EST_Token.h
@@ -327,7 +327,7 @@ class EST_TokenStream{
     /// peek at next token
     EST_Token &peek(void);
     /// Reading binary data, (don't use peek() immediately beforehand)
-    int fread(void *buff,int size,int nitems);
+    int fread(void *buff,int size,int nitems) EST_WARN_UNUSED_RESULT;
     //@}
     /**@name stream initialization functions */
     //@{

--- a/include/EST_common.h
+++ b/include/EST_common.h
@@ -43,6 +43,14 @@
 
 /* all this stuff should be common to C and C++ */
 
+#if defined __GNUC__
+  #define EST_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
+#elif defined __clang__
+  #define EST_WARN_UNUSED_RESULT __attribute__((annotate("lo_warn_unused")))
+#else
+  #define EST_WARN_UNUSED_RESULT
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/speech_class/EST_wave_io.cc
+++ b/speech_class/EST_wave_io.cc
@@ -458,7 +458,8 @@ enum EST_read_status load_wave_riff(EST_TokenStream &ts, short **data, int
 	return wrong_format;
 
     /* We've got a riff file */
-    ts.fread(&dsize,4,1);
+    /* Next 4 bytes are the file size */
+    if(ts.fread(&dsize,4,1) != 1) return misc_read_error;
     /* .wav files are always little endian */
     if (EST_BIG_ENDIAN) dsize = SWAPINT(dsize);
     if ((ts.fread(info,sizeof(char),4) != 4) ||
@@ -471,9 +472,9 @@ enum EST_read_status load_wave_riff(EST_TokenStream &ts, short **data, int
 	(strncmp(info,"fmt ",4) != 0))
 	return misc_read_error;	/* something else wrong */
 
-    ts.fread(&dsize,4,1);
+    if (ts.fread(&dsize,4,1) != 1) return misc_read_error;
     if (EST_BIG_ENDIAN) dsize = SWAPINT(dsize);
-    ts.fread(&shortdata,2,1);
+    if (ts.fread(&shortdata,2,1) != 1) return misc_read_error;
     if (EST_BIG_ENDIAN) shortdata = SWAPSHORT(shortdata);
 
     switch (shortdata)
@@ -495,16 +496,16 @@ enum EST_read_status load_wave_riff(EST_TokenStream &ts, short **data, int
 	actual_sample_type = st_short;
 	/*	return misc_read_error; */
     }
-    ts.fread(&shortdata,2,1);
+    if (ts.fread(&shortdata,2,1) != 1) return misc_read_error;
     if (EST_BIG_ENDIAN) shortdata = SWAPSHORT(shortdata);
     *num_channels = shortdata;
-    ts.fread(sample_rate,4,1);
+    if (ts.fread(sample_rate,4,1) != 1) return misc_read_error;
     if (EST_BIG_ENDIAN) *sample_rate = SWAPINT(*sample_rate);
-    ts.fread(&intdata,4,1);	/* average bytes per second -- ignored */
+    if (ts.fread(&intdata,4,1) != 1) return misc_read_error; /* average bytes per second -- ignored */
     if (EST_BIG_ENDIAN) intdata = SWAPINT(intdata);
-    ts.fread(&shortdata,2,1);	/* block align ? */
+    if (ts.fread(&shortdata,2,1) != 1) return misc_read_error;	/* block align ? */
     if (EST_BIG_ENDIAN) shortdata = SWAPSHORT(shortdata);
-    ts.fread(&shortdata,2,1);
+    if (ts.fread(&shortdata,2,1) != 1) return misc_read_error;
     if (EST_BIG_ENDIAN) shortdata = SWAPSHORT(shortdata);
 
     sample_width = (shortdata+7)/8;
@@ -521,14 +522,14 @@ enum EST_read_status load_wave_riff(EST_TokenStream &ts, short **data, int
 	}
 	if (strncmp(info,"data",4) == 0)
 	{
-	    ts.fread(&samps,4,1);
+	    if (ts.fread(&samps,4,1) != 1) return misc_read_error;
 	    if (EST_BIG_ENDIAN) samps = SWAPINT(samps);
 	    samps /= (sample_width*(*num_channels));
 	    break;
 	}
 	else if (strncmp(info,"fact",4) == 0)
 	{			/* some other type of chunk -- skip it */
-	    ts.fread(&samps,4,1);
+	    if (ts.fread(&samps,4,1) != 1) return misc_read_error;
 	    if (EST_BIG_ENDIAN) samps = SWAPINT(samps);
 	    ts.seek(samps+ts.tell());	/* skip rest of header */
 	    /* Hope this is the right amount */
@@ -538,7 +539,7 @@ enum EST_read_status load_wave_riff(EST_TokenStream &ts, short **data, int
             //	    fprintf(stderr,"Ignoring unsupported chunk type \"%c%c%c%c\" in RIFF file\n",
             //    info[0],info[1],info[2],info[3]);
 	    //return misc_read_error;
-	    ts.fread(&dsize,4,1);
+	    if(ts.fread(&dsize,4,1) != 1) return misc_read_error;
 	    if (EST_BIG_ENDIAN) dsize = SWAPINT(dsize);
 	    ts.seek(dsize+ts.tell());     /* skip this chunk */
 	}
@@ -680,7 +681,7 @@ enum EST_read_status load_wave_aiff(EST_TokenStream &ts, short **data, int
 	return wrong_format;
 
     /* We've got an aiff file, I hope */
-    ts.fread(&dsize,4,1);
+    if (ts.fread(&dsize,4,1) != 1) return misc_read_error;
     if (EST_LITTLE_ENDIAN)	/* file is in different byte order */
 	dsize = SWAPINT(dsize);
     if ((ts.fread(info,sizeof(char),4) != 4) ||
@@ -690,7 +691,7 @@ enum EST_read_status load_wave_aiff(EST_TokenStream &ts, short **data, int
 	return misc_read_error; 
     }
     
-    for ( ; ts.fread(&chunk,1,sizeof(chunk)) == sizeof(chunk) ; )
+    for ( ; ts.fread(&chunk, sizeof(chunk), 1) == 1 ; )
     {				/* for each chunk in the file */
 	if (EST_LITTLE_ENDIAN)	/* file is in different byte order */
 	    chunk.size = SWAPINT(chunk.size);
@@ -701,10 +702,13 @@ enum EST_read_status load_wave_aiff(EST_TokenStream &ts, short **data, int
 		fprintf(stderr,"AIFF chunk: bad size\n");
 		return misc_read_error;
 	    }
-	    ts.fread(&comm_channels,1,sizeof(short));
-	    ts.fread(&comm_samples,1,sizeof(int));
-	    ts.fread(&comm_bits,1,sizeof(short));
-	    if (ts.fread(ieee_ext_sample_rate,1,10) != 10)
+	    if (ts.fread(&comm_channels, sizeof(short), 1) != 1)
+            return misc_read_error;
+	    if (ts.fread(&comm_samples, sizeof(int), 1) != 1)
+            return misc_read_error;
+	    if (ts.fread(&comm_bits, sizeof(short), 1) != 1)
+            return misc_read_error;
+	    if (ts.fread(ieee_ext_sample_rate, 10, 1) != 1)
 	    {
 		fprintf(stderr,"AIFF chunk: eof within COMM chunk\n");
 		return misc_read_error;
@@ -719,7 +723,7 @@ enum EST_read_status load_wave_aiff(EST_TokenStream &ts, short **data, int
 	}
 	else if (strncmp(chunk.id,"SSND",4) == 0)
 	{
-	    if (ts.fread(&ssndchunk,1,sizeof(ssndchunk)) != sizeof(ssndchunk))
+	    if (ts.fread(&ssndchunk, sizeof(ssndchunk), 1) != 1)
 	    {
 		fprintf(stderr,"AIFF chunk: eof within SSND chunk\n");
 		return misc_read_error;
@@ -924,7 +928,8 @@ enum EST_read_status load_wave_snd(EST_TokenStream &ts, short **data, int
     int current_pos;
     
     current_pos = ts.tell();
-    ts.fread(&header, sizeof(Sun_au_header), 1);
+    if (ts.fread(&header, sizeof(Sun_au_header), 1) != 1)
+        return misc_read_error;
     
     /* test for magic number */
     if ((EST_LITTLE_ENDIAN) && 
@@ -1120,12 +1125,16 @@ enum EST_read_status load_wave_audlab(EST_TokenStream &ts, short **data, int
     
     /* Read header structures from char array */
     current_pos = ts.tell();
-    ts.fread(&fh, sizeof(struct audlabfh), 1);
+
+    if (ts.fread(&fh, sizeof(struct audlabfh), 1) != 1)
+        return misc_read_error;
     if (strcmp(fh.file_type, "Sample") != 0) 
 	return wrong_format;
     
-    ts.fread(&sh, sizeof(struct audlabsh), 1);
-    ts.fread(&sd, sizeof(struct audlabsd), 1);
+    if (ts.fread(&sh, sizeof(struct audlabsh), 1) != 1)
+        return misc_read_error;
+    if (ts.fread(&sd, sizeof(struct audlabsd), 1) != 1)
+        return misc_read_error;
     hdr_length = sizeof(struct audlabfh) +
 	sizeof(struct audlabsh) +
 	    sizeof(struct audlabsd);


### PR DESCRIPTION
fread return values should be checked for errors. This patch:
- annotates the tokenstream.fread function to be checked (gcc and clang will give a warning if it is not checked)
-  checks the tokenstream.fread function calls

Also imported from Debian