### PR TITLE
Fix building with GCC-10

### DIFF
--- a/siod/editline.c
+++ b/siod/editline.c
@@ -73,7 +73,6 @@
 /* modified by awb to allow specifcation of history size at run time  */
 /* (though only once)                                                 */
 int editline_histsize=256;
-char *editline_history_file;
 /* If this is defined it'll be called for completion first, before the */
 /* internal file name completion will be                               */
 EL_USER_COMPLETION_FUNCTION_TYPE*el_user_completion_function = NULL;


### PR DESCRIPTION
Building with GCC-10 fails with
```
x86_64-pc-linux-gnu-g++ -shared -o libestools.so.2.5.0.1 -Wl,-soname,libestools.so.2.5.0.1 shared_space/*.o  $libs
/usr/lib/gcc/x86_64-pc-linux-gnu/10.1.0/../../../../x86_64-pc-linux-gnu/bin/ld: shared_space/siodeditline.o:(.data.rel.local+0x8): multiple definition of `editline_history_file'; shared_space/editline.o:(.bss+0x28): first defined here
```
GCC-10 now defaults to using `-fno-common`.  This causes any global declarations without `extern` specifier to be treated as a definition.   `editline_history_file` is defined and initialized in [siodeditline.c](https://github.com/festvox/speech_tools/blob/645fd64933b7332969e6e35b306db7be8bebdeaf/siod/siodeditline.c#L103).  An extern qualified forward declaration is already included  from [editline.h](https://github.com/festvox/speech_tools/blob/645fd64933b7332969e6e35b306db7be8bebdeaf/siod/editline.h#L132).  Removing the erroneous redundant definition from `editline.c` resolves the issue.

Fixes https://github.com/festvox/speech_tools/issues/20.