### PR TITLE
Add methods to EST_Wave for saving wave files by parts

### DIFF
--- a/include/EST_Wave.h
+++ b/include/EST_Wave.h
@@ -298,11 +298,19 @@ public:
 
   EST_write_status save_file(const EST_String filename, 
 			     EST_String filetype,
-			     EST_String sample_type, int bo);
+			     EST_String sample_type, int bo,
+			     const char *mode = "wb");
 
   EST_write_status save_file(FILE *fp,
 			     EST_String filetype,
 			     EST_String sample_type, int bo);
+
+  EST_write_status save_file_header(FILE *fp,
+				     EST_String ftype,
+				     EST_String stype, int obo);
+  EST_write_status save_file_data(FILE *fp,
+				     EST_String ftype,
+				     EST_String stype, int obo);
   //@}
 
   /// Assignment operator

--- a/include/EST_wave_aux.h
+++ b/include/EST_wave_aux.h
@@ -116,6 +116,13 @@ enum EST_sample_type_t {
   st_alaw, 
   st_ascii};
 
+
+enum EST_write_status wave_io_save_header(FILE *fp,
+                      const int num_samples, const int num_channels,
+                      const int sample_rate,
+                      const EST_String& stype, const int bo,
+                      const EST_String& ftype);
+
 extern EST_TNamedEnum<EST_sample_type_t> EST_sample_type_map;
 
 #endif /* __EST_WAVE_AUX_H__ */

--- a/speech_class/EST_Wave.cc
+++ b/speech_class/EST_Wave.cc
@@ -394,13 +394,14 @@ EST_write_status EST_Wave::save(FILE *fp, const EST_String type)
 
 EST_write_status EST_Wave::save_file(const EST_String filename,
 				     EST_String ftype,
-				     EST_String stype, int obo)
+				     EST_String stype, int obo,
+				     const char *mode)
 {
     FILE *fp;
 
     if (filename == "-")
 	fp = stdout;
-    else if ((fp = fopen(filename,"wb")) == NULL)
+    else if ((fp = fopen(filename, mode)) == NULL)
     {
 	cerr << "Wave save: can't open output file \"" <<
 	    filename << "\"" << endl;
@@ -435,7 +436,55 @@ EST_write_status EST_Wave::save_file(FILE *fp,
     }
     
     return (*s_fun)(fp, *this, sample_type, obo);
+}
     
+EST_write_status EST_Wave::save_file_data(FILE *fp,
+				     EST_String ftype,
+				     EST_String stype, int obo)
+{
+    EST_WaveFileType t = EST_WaveFile::map.token(ftype);
+    EST_sample_type_t sample_type = EST_sample_type_map.token(stype);
+
+    if (t == wff_none)
+      {
+	cerr << "Unknown Wave file type " << ftype << endl;
+	return write_fail;
+      }
+
+    EST_WaveFile::Save_TokenStream * s_fun = EST_WaveFile::map.info(t).save_data;
+    
+    if (s_fun == NULL)
+    {
+	cerr << "Can't save wave data to files type " << ftype << endl;
+	return write_fail;
+    }
+
+    return (*s_fun)(fp, *this, sample_type, obo);
+}
+
+
+EST_write_status EST_Wave::save_file_header(FILE *fp,
+				     EST_String ftype,
+				     EST_String stype, int obo)
+{
+    EST_WaveFileType t = EST_WaveFile::map.token(ftype);
+    EST_sample_type_t sample_type = EST_sample_type_map.token(stype);
+
+    if (t == wff_none)
+      {
+	cerr << "Unknown Wave file type " << ftype << endl;
+	return write_fail;
+      }
+
+    EST_WaveFile::Save_TokenStream * s_fun = EST_WaveFile::map.info(t).save_header;
+
+    if (s_fun == NULL)
+    {
+	cerr << "Can't save wave header to files type " << ftype << endl;
+	return write_fail;
+    }
+
+    return (*s_fun)(fp, *this, sample_type, obo);
 }
 
 void EST_Wave::resample(int new_freq)

--- a/speech_class/EST_WaveFile.cc
+++ b/speech_class/EST_WaveFile.cc
@@ -43,8 +43,8 @@
 #include "EST_cutils.h"
 #include "EST_Option.h"
 #include "EST_io_aux.h"
-#include "stdio.h"
-#include "math.h"
+#include <cstdio>
+#include <cmath>
 
 void extract(EST_Wave &sig, EST_Option &al);
 
@@ -63,6 +63,11 @@ EST_write_status (*standard_save_fn_fp)(FILE *fp,
 				    int nchan, int srate,
 				    EST_sample_type_t stype, int bo);
 				    
+typedef
+EST_write_status (*standard_save_header_fn_fp)(FILE *fp,
+				    int nsamp,
+				    int nchan, int srate,
+				    EST_sample_type_t stype, int bo);
   
 static 
 EST_read_status load_using(standard_load_fn_fp fn,
@@ -109,6 +114,19 @@ EST_write_status status =  (*fn)(fp,
 return status; 
 }
 
+static
+EST_write_status save_header_using(standard_save_header_fn_fp fn,
+			    FILE *fp, const EST_Wave wv,
+			    EST_sample_type_t stype, int bo)
+{
+
+EST_write_status status =  (*fn)(fp,
+                wv.num_samples(), wv.num_channels(),
+				wv.sample_rate(),
+				stype, bo);
+return status;
+}
+
 EST_read_status EST_WaveFile::load_nist(EST_TokenStream &ts,
 			  EST_Wave &wv,
 			  int rate,
@@ -126,6 +144,20 @@ EST_write_status EST_WaveFile::save_nist(FILE *fp,
 					 EST_sample_type_t stype, int bo)
 {
   return save_using(save_wave_nist, fp, wv, stype, bo);
+}
+
+EST_write_status EST_WaveFile::save_nist_data(FILE *fp,
+					 const EST_Wave &wv,
+					 EST_sample_type_t stype, int bo)
+{
+  return save_using(save_wave_nist_data, fp, wv, stype, bo);
+}
+
+EST_write_status EST_WaveFile::save_nist_header(FILE *fp,
+					 const EST_Wave &wv,
+					 EST_sample_type_t stype, int bo)
+{
+  return save_header_using(save_wave_nist_header, fp, wv, stype, bo);
 }
 
 EST_read_status EST_WaveFile::load_est(EST_TokenStream &ts,
@@ -149,7 +181,24 @@ EST_write_status EST_WaveFile::save_est(FILE *fp,
   return save_using(save_wave_est,
 		    fp, wv,
 		    stype, bo);
+}
 
+EST_write_status EST_WaveFile::save_est_data(FILE *fp,
+					 const EST_Wave &wv,
+					 EST_sample_type_t stype, int bo)
+{
+  return save_using(save_wave_est_data,
+		    fp, wv,
+		    stype, bo);
+}
+
+EST_write_status EST_WaveFile::save_est_header(FILE *fp,
+					 const EST_Wave &wv,
+					 EST_sample_type_t stype, int bo)
+{
+  return save_header_using(save_wave_est_header,
+		    fp, wv,
+		    stype, bo);
 }
 
 EST_read_status EST_WaveFile::load_aiff(EST_TokenStream &ts, 
@@ -171,6 +220,19 @@ EST_write_status EST_WaveFile::save_aiff(FILE *fp,
   return save_using(save_wave_aiff, fp, wv, stype, bo);
 }
 
+EST_write_status EST_WaveFile::save_aiff_data(FILE *fp,
+					 const EST_Wave &wv,
+					 EST_sample_type_t stype, int bo)
+{
+  return save_using(save_wave_aiff_data, fp, wv, stype, bo);
+}
+
+EST_write_status EST_WaveFile::save_aiff_header(FILE *fp,
+					 const EST_Wave &wv,
+					 EST_sample_type_t stype, int bo)
+{
+  return save_header_using(save_wave_aiff_header, fp, wv, stype, bo);
+}
 
 EST_read_status EST_WaveFile::load_riff(EST_TokenStream &ts,
 			  EST_Wave &wv,
@@ -191,6 +253,19 @@ EST_write_status EST_WaveFile::save_riff(FILE *fp,
   return save_using(save_wave_riff, fp, wv, stype, bo);
 }
 
+EST_write_status EST_WaveFile::save_riff_data(FILE *fp,
+					 const EST_Wave &wv,
+					 EST_sample_type_t stype, int bo)
+{
+  return save_using(save_wave_riff_data, fp, wv, stype, bo);
+}
+
+EST_write_status EST_WaveFile::save_riff_header(FILE *fp,
+					 const EST_Wave &wv,
+					 EST_sample_type_t stype, int bo)
+{
+  return save_header_using(save_wave_riff_header, fp, wv, stype, bo);
+}
 
 EST_read_status EST_WaveFile::load_esps(EST_TokenStream &ts, 
 			  EST_Wave &wv,
@@ -213,6 +288,23 @@ EST_write_status EST_WaveFile::save_esps(FILE *fp,
 		    stype, bo);
 }
 
+EST_write_status EST_WaveFile::save_esps_data(FILE *fp,
+					 const EST_Wave &wv,
+					 EST_sample_type_t stype, int bo)
+{
+  return save_using(save_wave_sd_data,
+		    fp, wv,
+		    stype, bo);
+}
+
+EST_write_status EST_WaveFile::save_esps_header(FILE *fp,
+					 const EST_Wave &wv,
+					 EST_sample_type_t stype, int bo)
+{
+  return save_header_using(save_wave_sd_header,
+		    fp, wv,
+		    stype, bo);
+}
 
 EST_read_status EST_WaveFile::load_audlab(EST_TokenStream &ts, 
 			  EST_Wave &wv,
@@ -233,6 +325,19 @@ EST_write_status EST_WaveFile::save_audlab(FILE *fp,
   return save_using(save_wave_audlab, fp, wv, stype, bo);
 }
 
+EST_write_status EST_WaveFile::save_audlab_data(FILE *fp,
+					 const EST_Wave &wv,
+					 EST_sample_type_t stype, int bo)
+{
+  return save_using(save_wave_audlab_data, fp, wv, stype, bo);
+}
+
+EST_write_status EST_WaveFile::save_audlab_header(FILE *fp,
+					 const EST_Wave &wv,
+					 EST_sample_type_t stype, int bo)
+{
+  return save_header_using(save_wave_audlab_header, fp, wv, stype, bo);
+}
 
 EST_read_status EST_WaveFile::load_snd(EST_TokenStream &ts, 
 			  EST_Wave &wv,
@@ -252,6 +357,21 @@ EST_write_status EST_WaveFile::save_snd(FILE *fp,
 {
   return save_using(save_wave_snd, fp, wv, stype, bo);
 }
+
+EST_write_status EST_WaveFile::save_snd_data(FILE *fp,
+					const EST_Wave &wv,
+					EST_sample_type_t stype, int bo)
+{
+  return save_using(save_wave_snd_data, fp, wv, stype, bo);
+}
+
+EST_write_status EST_WaveFile::save_snd_header(FILE *fp,
+					const EST_Wave &wv,
+					EST_sample_type_t stype, int bo)
+{
+  return save_header_using(save_wave_snd_header, fp, wv, stype, bo);
+}
+
 
 
 EST_read_status EST_WaveFile::load_raw(EST_TokenStream &ts, 
@@ -293,6 +413,20 @@ EST_write_status status =  save_wave_raw(fp,
 return status; 
 }
 
+EST_write_status EST_WaveFile::save_raw_data(FILE *fp,
+					 const EST_Wave &wv,
+					 EST_sample_type_t stype, int bo)
+{
+return save_raw(fp, wv, stype, bo);
+}
+
+
+EST_write_status EST_WaveFile::save_raw_header(FILE *fp,
+					 const EST_Wave &wv,
+					 EST_sample_type_t stype, int bo)
+{
+  return save_header_using(save_wave_raw_header, fp, wv, stype, bo);
+}
 
 EST_read_status EST_WaveFile::load_ulaw(EST_TokenStream &ts,
 			  EST_Wave &wv,
@@ -315,6 +449,25 @@ EST_write_status EST_WaveFile::save_ulaw(FILE *fp,
     return save_using(save_wave_ulaw, fp, localwv, stype, bo);
 }
 
+EST_write_status EST_WaveFile::save_ulaw_data(FILE *fp,
+					 const EST_Wave &wv,
+					 EST_sample_type_t stype, int bo)
+{
+    EST_Wave localwv = wv;
+    localwv.resample(8000);
+    return save_using(save_wave_ulaw_data, fp, localwv, stype, bo);
+}
+
+
+EST_write_status EST_WaveFile::save_ulaw_header(FILE *fp,
+					 const EST_Wave &wv,
+					 EST_sample_type_t stype, int bo)
+{
+    EST_Wave localwv = wv;
+    localwv.resample(8000);
+    return save_header_using(save_wave_ulaw_header, fp, localwv, stype, bo);
+}
+
 EST_read_status EST_WaveFile::load_alaw(EST_TokenStream &ts,
   EST_Wave &wv,
   int rate,
@@ -325,6 +478,24 @@ EST_read_status EST_WaveFile::load_alaw(EST_TokenStream &ts,
     ts, wv, rate, 
     stype, bo, nchan,
     offset, length);
+}
+
+EST_write_status EST_WaveFile::save_alaw_header(FILE *fp,
+					 const EST_Wave &wv,
+					 EST_sample_type_t stype, int bo)
+{
+    EST_Wave localwv = wv;
+    localwv.resample(8000);
+    return save_header_using(save_wave_alaw_header, fp, localwv, stype, bo);
+}
+
+EST_write_status EST_WaveFile::save_alaw_data(FILE *fp,
+					 const EST_Wave &wv,
+					 EST_sample_type_t stype, int bo)
+{
+    EST_Wave localwv = wv;
+    localwv.resample(8000);
+    return save_using(save_wave_alaw_data, fp, localwv, stype, bo);
 }
 
 EST_write_status EST_WaveFile::save_alaw(FILE *fp,
@@ -577,25 +748,47 @@ static
 EST_TValuedEnumDefinition<EST_WaveFileType, const char *, EST_WaveFile::Info> wavefile_names[] =
 {
   { wff_none,	{ NULL }, 
-    { FALSE, NULL, NULL, "unknown track file type"} },
+    { FALSE, NULL, NULL, NULL, NULL, "unknown track file type"} },
   { wff_nist,	{ "nist", "timit" }, 
-    { TRUE, EST_WaveFile::load_nist,  EST_WaveFile::save_nist, "nist/timit" } },
+    { TRUE, EST_WaveFile::load_nist,  EST_WaveFile::save_nist,
+      EST_WaveFile::save_nist_header, EST_WaveFile::save_nist_data,
+      "nist/timit" } },
   { wff_est,	{ "est"}, 
-    { TRUE, EST_WaveFile::load_est,  EST_WaveFile::save_est, "est" } },
+    { TRUE, EST_WaveFile::load_est,  EST_WaveFile::save_est,
+      EST_WaveFile::save_est_header, EST_WaveFile::save_est_data,
+      "est" } },
   { wff_esps,	{ "esps", "sd"}, 
-    { TRUE,  EST_WaveFile::load_esps,  EST_WaveFile::save_esps, "esps SD waveform" } },
+    { TRUE,  EST_WaveFile::load_esps,  EST_WaveFile::save_esps,
+      EST_WaveFile::save_esps_header, EST_WaveFile::save_esps_data,
+      "esps SD waveform" } },
   { wff_audlab, { "audlab", "vox"}, 
-    { TRUE,  EST_WaveFile::load_audlab,  EST_WaveFile::save_audlab, "audlab waveform" } },
+    { TRUE,  EST_WaveFile::load_audlab,  EST_WaveFile::save_audlab,
+      EST_WaveFile::save_audlab_header, EST_WaveFile::save_audlab_data,
+      "audlab waveform" } },
   { wff_snd,	{ "snd", "au"}, 
-    { TRUE,  EST_WaveFile::load_snd,  EST_WaveFile::save_snd, "Sun snd file" } },
+    { TRUE,  EST_WaveFile::load_snd,  EST_WaveFile::save_snd,
+      EST_WaveFile::save_snd_header, EST_WaveFile::save_snd_data,
+      "Sun snd file" } },
   { wff_aiff,	{ "aiff" }, 
-    { TRUE,  EST_WaveFile::load_aiff,  EST_WaveFile::save_aiff, "Apple aiff file" } },
+    { TRUE,  EST_WaveFile::load_aiff,  EST_WaveFile::save_aiff,
+      EST_WaveFile::save_aiff_header, EST_WaveFile::save_aiff_data,
+      "Apple aiff file" } },
   { wff_riff,	{ "riff", "wav" }, 
-    { TRUE,  EST_WaveFile::load_riff,  EST_WaveFile::save_riff, "Microsoft wav/riff file" } },
+    { TRUE,  EST_WaveFile::load_riff,  EST_WaveFile::save_riff,
+      EST_WaveFile::save_riff_header, EST_WaveFile::save_riff_data,
+      "Microsoft wav/riff file" } },
   { wff_raw,	{ "raw" }, 
-    { FALSE,  EST_WaveFile::load_raw,  EST_WaveFile::save_raw, "Headerless File" } },
+    { FALSE,  EST_WaveFile::load_raw,  EST_WaveFile::save_raw,
+      EST_WaveFile::save_raw_header, EST_WaveFile::save_raw_data,
+      "Headerless File" } },
   { wff_ulaw,	{ "ulaw", "basic" }, 
-    { FALSE,  EST_WaveFile::load_ulaw,  EST_WaveFile::save_ulaw, "Headerless 8K ulaw  File" } },
+    { FALSE,  EST_WaveFile::load_ulaw,  EST_WaveFile::save_ulaw,
+      EST_WaveFile::save_ulaw_header, EST_WaveFile::save_ulaw_data,
+      "Headerless 8K ulaw  File" } },
+  { wff_alaw,	{ "alaw", "basic" }, 
+    { FALSE,  EST_WaveFile::load_alaw,  EST_WaveFile::save_alaw,
+      EST_WaveFile::save_alaw_header, EST_WaveFile::save_alaw_data,
+      "Headerless 8K alaw  File" } },
   { wff_none,	{NULL} }
 };
 

--- a/speech_class/EST_WaveFile.h
+++ b/speech_class/EST_WaveFile.h
@@ -96,37 +96,59 @@ public:
     bool recognise;
     Load_TokenStream *load;
     Save_TokenStream *save;
+    Save_TokenStream *save_header;
+    Save_TokenStream *save_data;
     const char *description;
   } Info;
 
   static EST_write_status save_nist(SaveWave_TokenStreamArgs);
+  static EST_write_status save_nist_header(SaveWave_TokenStreamArgs);
+  static EST_write_status save_nist_data(SaveWave_TokenStreamArgs);
   static EST_read_status load_nist(LoadWave_TokenStreamArgs);
 
   static EST_write_status save_est(SaveWave_TokenStreamArgs);
+  static EST_write_status save_est_header(SaveWave_TokenStreamArgs);
+  static EST_write_status save_est_data(SaveWave_TokenStreamArgs);
   static EST_read_status load_est(LoadWave_TokenStreamArgs);
 
   static EST_write_status save_esps(SaveWave_TokenStreamArgs);
+  static EST_write_status save_esps_header(SaveWave_TokenStreamArgs);
+  static EST_write_status save_esps_data(SaveWave_TokenStreamArgs);
   static EST_read_status load_esps(LoadWave_TokenStreamArgs);
 
   static EST_write_status save_audlab(SaveWave_TokenStreamArgs);
+  static EST_write_status save_audlab_header(SaveWave_TokenStreamArgs);
+  static EST_write_status save_audlab_data(SaveWave_TokenStreamArgs);
   static EST_read_status load_audlab(LoadWave_TokenStreamArgs);
 
   static EST_write_status save_snd(SaveWave_TokenStreamArgs);
+  static EST_write_status save_snd_header(SaveWave_TokenStreamArgs);
+  static EST_write_status save_snd_data(SaveWave_TokenStreamArgs);
   static EST_read_status load_snd(LoadWave_TokenStreamArgs);
 
   static EST_write_status save_aiff(SaveWave_TokenStreamArgs);
+  static EST_write_status save_aiff_header(SaveWave_TokenStreamArgs);
+  static EST_write_status save_aiff_data(SaveWave_TokenStreamArgs);
   static EST_read_status load_aiff(LoadWave_TokenStreamArgs);
 
   static EST_write_status save_riff(SaveWave_TokenStreamArgs);
+  static EST_write_status save_riff_header(SaveWave_TokenStreamArgs);
+  static EST_write_status save_riff_data(SaveWave_TokenStreamArgs);
   static EST_read_status load_riff(LoadWave_TokenStreamArgs);
 
   static EST_write_status save_raw(SaveWave_TokenStreamArgs);
+  static EST_write_status save_raw_header(SaveWave_TokenStreamArgs);
+  static EST_write_status save_raw_data(SaveWave_TokenStreamArgs);
   static EST_read_status load_raw(LoadWave_TokenStreamArgs);
 
   static EST_write_status save_ulaw(SaveWave_TokenStreamArgs);
+  static EST_write_status save_ulaw_header(SaveWave_TokenStreamArgs);
+  static EST_write_status save_ulaw_data(SaveWave_TokenStreamArgs);
   static EST_read_status load_ulaw(LoadWave_TokenStreamArgs);
 
   static EST_write_status save_alaw(SaveWave_TokenStreamArgs);
+  static EST_write_status save_alaw_header(SaveWave_TokenStreamArgs);
+  static EST_write_status save_alaw_data(SaveWave_TokenStreamArgs);
   static EST_read_status load_alaw(LoadWave_TokenStreamArgs);
 
   static EST_TNamedEnumI<EST_WaveFileType, Info> map;

--- a/speech_class/EST_wave_io.cc
+++ b/speech_class/EST_wave_io.cc
@@ -294,10 +294,10 @@ enum EST_read_status load_wave_nist(EST_TokenStream &ts, short **data, int
     return format_ok;
 }
 
-enum EST_write_status save_wave_nist(FILE *fp, const short *data, int offset,
-				     int num_samples, int num_channels, 
-				     int sample_rate,
-				     enum EST_sample_type_t sample_type, int bo)   
+enum EST_write_status save_wave_nist_header(FILE *fp,
+					    int num_samples, int num_channels, 
+					    int sample_rate,
+					    enum EST_sample_type_t sample_type, int bo)   
 {
     char h[1024], p[1024];
     const char *t;
@@ -335,9 +335,33 @@ enum EST_write_status save_wave_nist(FILE *fp, const short *data, int offset,
     if (fwrite(&h, 1024, 1, fp) != 1)
 	return misc_write_error;
     
+    return write_ok;
+}
+
+
+enum EST_write_status save_wave_nist_data(FILE *fp, const short *data, int offset,
+					  int num_samples, int num_channels,
+					  int sample_rate,
+					  enum EST_sample_type_t sample_type, int bo)
+{
+    if (data == NULL)
+       return write_ok;
+    
     return save_raw_data(fp,data,offset,num_samples,num_channels,
 			 sample_type,bo);
     
+}
+
+enum EST_write_status save_wave_nist(FILE *fp, const short *data, int offset,
+				     int num_samples, int num_channels,
+				     int sample_rate,
+				     enum EST_sample_type_t sample_type, int bo)
+{
+    save_wave_nist_header(fp, num_samples, num_channels,
+			  sample_rate, sample_type, bo);
+    return save_wave_nist_data(fp, data, offset,
+			       num_samples, num_channels,
+			       sample_rate, sample_type, bo);
 }
 
 /*=======================================================================*/
@@ -412,10 +436,10 @@ enum EST_read_status load_wave_est(EST_TokenStream &ts, short **data, int
     return format_ok;
 }
 
-enum EST_write_status save_wave_est(FILE *fp, const short *data, int offset,
-				       int num_samples, int num_channels, 
-				       int sample_rate,
-				       enum EST_sample_type_t sample_type, int bo)   
+enum EST_write_status save_wave_est_header(FILE *fp,
+					   int num_samples, int num_channels, 
+					   int sample_rate,
+					   enum EST_sample_type_t sample_type, int bo)   
 {
     fprintf(fp, "EST_File wave\n");
     fprintf(fp, "DataType binary\n");
@@ -427,10 +451,32 @@ enum EST_write_status save_wave_est(FILE *fp, const short *data, int offset,
 	fprintf(fp, "ByteOrder %s\n", ((bo == bo_big) ? "10" : "01"));
     
     fprintf(fp, "EST_Header_End\n");
+    return write_ok;
+}
+
+enum EST_write_status save_wave_est_data(FILE *fp, const short *data, int offset,
+					 int num_samples, int num_channels,
+					 int sample_rate,
+					 enum EST_sample_type_t sample_type, int bo)
+{
+    if (data == NULL)
+       return write_ok;
     
     return save_raw_data(fp, data, offset, num_samples, num_channels,
 			 sample_type, bo);
+}
     
+enum EST_write_status save_wave_est(FILE *fp, const short *data, int offset,
+				    int num_samples, int num_channels,
+				    int sample_rate,
+				    enum EST_sample_type_t sample_type, int bo)
+{
+    save_wave_est_header(fp, num_samples, num_channels,
+			 sample_rate, sample_type, bo);
+    
+    return save_wave_est_data(fp, data, offset,
+			      num_samples, num_channels,
+			      sample_rate, sample_type, bo);
 }
 
 /*=======================================================================*/
@@ -588,10 +634,9 @@ enum EST_read_status load_wave_riff(EST_TokenStream &ts, short **data, int
     return format_ok;
 }
 
-enum EST_write_status save_wave_riff(FILE *fp, const short *data, int offset,
-				     int num_samples, int num_channels, 
-				     int sample_rate,
-				     enum EST_sample_type_t sample_type, int bo)   
+enum EST_write_status save_wave_riff_header(FILE *fp, int num_samples,
+					    int num_channels, int sample_rate,
+					    enum EST_sample_type_t sample_type, int bo)   
 {
     (void)bo;
     const char *info;
@@ -648,8 +693,33 @@ enum EST_write_status save_wave_riff(FILE *fp, const short *data, int offset,
     if (EST_BIG_ENDIAN) data_size = SWAPINT(data_size);
     fwrite(&data_size,1,4,fp);	/* total number of bytes in data */
     
+    return write_ok;
+}
+
+enum EST_write_status save_wave_riff_data(FILE *fp, const short *data,
+					  int offset, int num_samples, int num_channels,
+					  int sample_rate,
+					  enum EST_sample_type_t sample_type, int bo)
+{
+    if (data == NULL)
+       return write_ok;
+    
     return save_raw_data(fp,data,offset,num_samples,num_channels,
 			 sample_type,bo_little);
+}
+
+
+enum EST_write_status save_wave_riff(FILE *fp, const short *data, int offset,
+				     int num_samples, int num_channels,
+				     int sample_rate,
+				     enum EST_sample_type_t sample_type, int bo)
+{
+    save_wave_riff_header(fp, num_samples, num_channels, sample_rate,
+			  sample_type, bo);
+
+    return save_wave_riff_data(fp, data, offset, num_samples,
+			       num_channels, sample_rate, sample_type, bo);
+
 }
 
 /*=======================================================================*/
@@ -791,10 +861,10 @@ enum EST_read_status load_wave_aiff(EST_TokenStream &ts, short **data, int
     return format_ok;
 }
 
-enum EST_write_status save_wave_aiff(FILE *fp, const short *data, int offset,
-				     int num_samples, int num_channels, 
-				     int sample_rate,
-				     enum EST_sample_type_t sample_type, int bo)   
+enum EST_write_status save_wave_aiff_header(FILE *fp,
+					    int num_samples, int num_channels, 
+					    int sample_rate,
+					    enum EST_sample_type_t sample_type, int bo)   
 {
     (void)bo;
     const char *info;
@@ -845,16 +915,40 @@ enum EST_write_status save_wave_aiff(FILE *fp, const short *data, int offset,
 	data_int = SWAPINT(data_int);
     fwrite(&data_int,1,4,fp);   /* blocksize */
     
-    if ((sample_type == st_short) ||
-	(sample_type == st_uchar))
-	return save_raw_data(fp,data,offset,num_samples,num_channels,
-			     sample_type,bo_big);
+    return write_ok;
+
+}
+
+enum EST_write_status save_wave_aiff_data(FILE *fp, const short *data, int offset,
+					  int num_samples, int num_channels,
+					  int sample_rate,
+					  enum EST_sample_type_t sample_type, int bo)
+{
+
+    if (data == NULL)
+       return write_ok;
+    if ((sample_type == st_short) || (sample_type == st_uchar))
+	    return save_raw_data(fp,data, offset, num_samples, num_channels,
+                             sample_type, bo_big);
     else
     {
 	fprintf(stderr,"AIFF: requested data type not uchar or short\n");
 	return misc_write_error;
     }
+    }
     
+
+enum EST_write_status save_wave_aiff(FILE *fp, const short *data, int offset,
+				     int num_samples, int num_channels,
+				     int sample_rate,
+				     enum EST_sample_type_t sample_type, int bo)
+{
+    save_wave_aiff_header(fp, num_samples, num_channels,
+                          sample_rate, sample_type, bo);
+
+    return save_wave_aiff_data(fp, data, offset,
+			       num_samples, num_channels,
+			       sample_rate, sample_type, bo);
 }
 
 /*=======================================================================*/
@@ -900,17 +994,43 @@ enum EST_read_status load_wave_ulaw(EST_TokenStream &ts, short **data, int
     return format_ok;
 }
 
-enum EST_write_status save_wave_ulaw(FILE *fp, const short *data, int offset,
+enum EST_write_status save_wave_ulaw_header(FILE *fp,
 				     int num_samples, int num_channels, 
 				     int sample_rate, 
 				     enum EST_sample_type_t sample_type, int bo)
 {
-    (void)sample_rate;
-    (void)sample_type;
+    (void) sample_rate;
+    (void) sample_type;
+    (void) fp;
+    (void) num_samples;
+    (void) num_channels;
+    (void) bo;
+    return write_ok;
+}
+
+enum EST_write_status save_wave_ulaw_data(FILE *fp, const short *data, int offset,
+				     int num_samples, int num_channels,
+				     int sample_rate,
+				     enum EST_sample_type_t sample_type, int bo)
+{
+    if (data == NULL)
+       return write_ok;
+
     return save_wave_raw(fp,data,offset,num_samples,num_channels,
 			 8000,st_mulaw,bo);
+}
 
+enum EST_write_status save_wave_ulaw(FILE *fp, const short *data, int offset,
+				     int num_samples, int num_channels,
+				     int sample_rate,
+				     enum EST_sample_type_t sample_type, int bo)
+{
+    save_wave_ulaw_header(fp, num_samples, num_channels,
+                          sample_rate, sample_type, bo);
 
+    return save_wave_ulaw_data(fp, data, offset,
+			       num_samples, num_channels,
+			       sample_rate, sample_type, bo);
 }
 
 enum EST_read_status load_wave_alaw(EST_TokenStream &ts, short **data, int
@@ -952,17 +1072,44 @@ enum EST_read_status load_wave_alaw(EST_TokenStream &ts, short **data, int
     return format_ok;
 }
 
-enum EST_write_status save_wave_alaw(FILE *fp, const short *data, int offset,
+enum EST_write_status save_wave_alaw_header(FILE *fp,
+				     int num_samples, int num_channels,
+				     int sample_rate,
+				     enum EST_sample_type_t sample_type, int bo)
+{
+    (void) sample_rate;
+    (void) sample_type;
+    (void) fp;
+    (void) num_samples;
+    (void) num_channels;
+    (void) bo;
+    return write_ok;
+}
+
+enum EST_write_status save_wave_alaw_data(FILE *fp, const short *data, int offset,
 				     int num_samples, int num_channels,
 				     int sample_rate,
 				     enum EST_sample_type_t sample_type, int bo)
 {
     (void)sample_rate;
     (void)sample_type;
+    if (data == NULL)
+       return write_ok;
     return save_wave_raw(fp,data,offset,num_samples,num_channels,
 			 8000,st_alaw,bo);
+}
 
+enum EST_write_status save_wave_alaw(FILE *fp, const short *data, int offset,
+				     int num_samples, int num_channels,
+				     int sample_rate,
+				     enum EST_sample_type_t sample_type, int bo)
+{
+    save_wave_alaw_header(fp, num_samples, num_channels,
+                          sample_rate, sample_type, bo);
 
+    return save_wave_alaw_data(fp, data, offset,
+			       num_samples, num_channels,
+			       sample_rate, sample_type, bo);
 }
 
 
@@ -1066,7 +1213,7 @@ enum EST_read_status load_wave_snd(EST_TokenStream &ts, short **data, int
     return read_ok;
 }
 
-enum EST_write_status save_wave_snd(FILE *fp, const short *data, int offset,
+enum EST_write_status save_wave_snd_header(FILE *fp,
 				    int num_samples, int num_channels, 
 				    int sample_rate, 
 				    enum EST_sample_type_t sample_type, int bo)
@@ -1119,10 +1266,34 @@ enum EST_write_status save_wave_snd(FILE *fp, const short *data, int offset,
     if (fwrite(&header, sizeof(header), 1, fp) != 1)
 	return misc_write_error;
 
+    return write_ok;
+}
+
+enum EST_write_status save_wave_snd_data(FILE *fp, const short *data, int offset,
+				    int num_samples, int num_channels,
+				    int sample_rate,
+				    enum EST_sample_type_t sample_type, int bo)
+{
+    if (data == NULL)
+       return write_ok;
+
     /* snd files are always in BIG_ENDIAN (sun) byte order */
     return save_raw_data(fp,data,offset,num_samples,num_channels,
 			 sample_type,bo_big);
 }
+
+
+enum EST_write_status save_wave_snd(FILE *fp, const short *data, int offset,
+				    int num_samples, int num_channels,
+				    int sample_rate,
+				    enum EST_sample_type_t sample_type, int bo)
+{
+    save_wave_snd_header(fp, num_samples, num_channels, sample_rate,
+                         sample_type, bo);
+    return save_wave_snd_data(fp, data, offset, num_samples,
+             num_channels, sample_rate, sample_type, bo);
+}
+
 
 /*=======================================================================*/
 /* CSTR Audlab files (from the last century)                             */
@@ -1239,7 +1410,7 @@ enum EST_read_status load_wave_audlab(EST_TokenStream &ts, short **data, int
     return format_ok;
 }
 
-enum EST_write_status save_wave_audlab(FILE *fp, const short *data, int offset,
+enum EST_write_status save_wave_audlab_header(FILE *fp,
 				       int num_samples, int num_channels, 
 				       int sample_rate, 
 				       enum EST_sample_type_t sample_type, int bo)
@@ -1280,10 +1451,32 @@ enum EST_write_status save_wave_audlab(FILE *fp, const short *data, int offset,
     fwrite (&fh, sizeof(fh), 1, fp);
     fwrite (&sh, sizeof(sh), 1, fp);
     fwrite (&sd, sizeof(sd), 1, fp);
+    return write_ok;
+}
+
+enum EST_write_status save_wave_audlab_data(FILE *fp, const short *data, int offset,
+					    int num_samples, int num_channels,
+					    int sample_rate,
+					    enum EST_sample_type_t sample_type, int bo)
+{
+    if (data == NULL)
+       return write_ok;
     
     /* write data*/
     return save_raw_data(fp,data,offset,num_samples,num_channels,
 			 st_short,bo_big);
+}
+
+enum EST_write_status save_wave_audlab(FILE *fp, const short *data, int offset,
+				       int num_samples, int num_channels,
+				       int sample_rate,
+				       enum EST_sample_type_t sample_type, int bo)
+{
+    save_wave_audlab_header(fp, num_samples, num_channels,
+			    sample_rate, sample_type, bo);
+    return save_wave_audlab_data(fp, data, offset,
+				 num_samples, num_channels,
+				 sample_rate, sample_type, bo);
 }
 
 /*=======================================================================*/
@@ -1376,10 +1569,11 @@ enum EST_read_status load_wave_sd(EST_TokenStream &ts, short **data, int
     
 }
 
-enum EST_write_status save_wave_sd(FILE *fp, const short *data, int offset,
-				   int num_samples, int num_channels, 
-				   int sample_rate, 
-				   enum EST_sample_type_t sample_type, int bo)
+
+enum EST_write_status save_wave_sd_header(FILE *fp,
+					  int num_samples, int num_channels, 
+					  int sample_rate, 
+					  enum EST_sample_type_t sample_type, int bo)
 
 {
     (void)bo;
@@ -1402,6 +1596,7 @@ enum EST_write_status save_wave_sd(FILE *fp, const short *data, int offset,
 		}
     /* I believe all of the following are necessary and in this order */
     add_field(hdr,"samples",esps_type,num_channels);
+    /* FIXME: What is this path doing here? */
     add_fea_special(hdr,ESPS_FEA_DIRECTORY,"margo:/disk/disk10/home/awb/projects/speech_tools/main");
     add_fea_special(hdr,ESPS_FEA_COMMAND,
 		    "EDST waveform written as ESPS FEA_SD.\n\
@@ -1417,9 +1612,35 @@ enum EST_write_status save_wave_sd(FILE *fp, const short *data, int offset,
     }
     /* lets ignore desired bo and sample type for the time being */
     delete_esps_hdr(hdr);
+    return write_ok;
+}
+
+
+enum EST_write_status save_wave_sd_data(FILE *fp, const short *data,
+					int offset,
+					int num_samples, int num_channels,
+					int sample_rate,
+					enum EST_sample_type_t sample_type, int bo)
+
+{
+    if (data == NULL)
+       return write_ok;
     
     return save_raw_data(fp,data,offset,num_samples,num_channels,
 			 sample_type,EST_NATIVE_BO);
+}
+
+enum EST_write_status save_wave_sd(FILE *fp, const short *data, int offset,
+				   int num_samples, int num_channels,
+				   int sample_rate,
+				   enum EST_sample_type_t sample_type, int bo)
+
+{
+    save_wave_sd_header(fp, num_samples, num_channels, sample_rate,
+                        sample_type, bo);
+    return save_wave_sd_data(fp, data, offset, num_samples,
+			     num_channels, sample_rate, sample_type, bo);
+
 }
 
 /*=======================================================================*/
@@ -1516,16 +1737,37 @@ enum EST_read_status load_wave_raw(EST_TokenStream &ts, short **data, int
     return format_ok;
 }
 
-enum EST_write_status save_wave_raw(FILE *fp, const short *data, 
+enum EST_write_status save_wave_raw_header(FILE *fp,
+				    int num_samples, int num_channels,
+				    int sample_rate,
+				    enum EST_sample_type_t sample_type, int bo)
+{
+    return write_ok;
+}
+
+enum EST_write_status save_wave_raw_data(FILE *fp, const short *data,
 				    int offset,
 				    int num_samples, int num_channels, 
 				    int sample_rate,
 				    enum EST_sample_type_t sample_type, int bo)   
 {
-    (void)sample_rate;
+    if (data == NULL)
+       return write_ok;
     
     return save_raw_data(fp,data,offset,num_samples,num_channels,
 			 sample_type,bo);
+}
+
+enum EST_write_status save_wave_raw(FILE *fp, const short *data,
+				    int offset,
+				    int num_samples, int num_channels,
+				    int sample_rate,
+				    enum EST_sample_type_t sample_type, int bo)
+{
+    (void)sample_rate;
+
+    return save_wave_raw_data(fp, data, offset, num_samples,
+			      num_channels, sample_rate, sample_type, bo);
 }
 
 /***********************************************************************/
@@ -1534,3 +1776,112 @@ enum EST_write_status save_wave_raw(FILE *fp, const short *data,
 /*                                                                     */
 /***********************************************************************/
 
+enum EST_write_status wave_io_save_header(FILE *fp,
+                      const int num_samples, const int num_channels,
+                      const int sample_rate,
+                      const EST_String& stype, const int bo,
+                      const EST_String& ftype)
+{
+    EST_WaveFileType t = EST_WaveFile::map.token(ftype);
+    EST_sample_type_t sample_type = EST_sample_type_map.token(stype);
+    switch(t)
+    {
+        case wff_nist:
+            return save_wave_nist_header(fp, num_samples, num_channels,
+                       sample_rate, sample_type, bo);
+            break;
+        case wff_esps:
+            return save_wave_sd_header(fp, num_samples, num_channels,
+                       sample_rate, sample_type, bo);
+            break;
+        case wff_est:
+            return save_wave_est_header(fp, num_samples, num_channels,
+                       sample_rate, sample_type, bo);
+            break;
+        case wff_audlab:
+            return save_wave_audlab_header(fp, num_samples, num_channels,
+                       sample_rate, sample_type, bo);
+            break;
+        case wff_snd:
+            return save_wave_snd_header(fp, num_samples, num_channels,
+                       sample_rate, sample_type, bo);
+            break;
+        case wff_aiff:
+            return save_wave_aiff_header(fp, num_samples, num_channels,
+                       sample_rate, sample_type, bo);
+            break;
+        case wff_riff:
+            return save_wave_riff_header(fp, num_samples, num_channels,
+                       sample_rate, sample_type, bo);
+            break;
+        case wff_raw:
+            return save_wave_raw_header(fp, num_samples, num_channels,
+                       sample_rate, sample_type, bo);
+            break;
+        case wff_ulaw:
+            return save_wave_ulaw_header(fp, num_samples, num_channels,
+                       sample_rate, sample_type, bo);
+            break;
+        default:
+        case wff_none:
+            cerr << "Can't save wave header to files type " << ftype << endl;
+            break;
+    }
+    return write_ok;
+}
+
+
+enum EST_write_status wave_io_save_data(FILE *fp, const short * data,
+                      const int offset,
+                      const int num_samples, const int num_channels,
+                      const int sample_rate,
+                      const EST_String& stype, const int bo,
+                      const EST_String& ftype)
+{
+    EST_WaveFileType t = EST_WaveFile::map.token(ftype);
+    EST_sample_type_t sample_type = EST_sample_type_map.token(stype);
+    switch(t)
+    {
+        case wff_nist:
+            return save_wave_nist_data(fp, data, offset, num_samples, num_channels,
+                       sample_rate, sample_type, bo);
+            break;
+        case wff_esps:
+            return save_wave_sd_data(fp, data, offset, num_samples, num_channels,
+                       sample_rate, sample_type, bo);
+            break;
+        case wff_est:
+            return save_wave_est_data(fp, data, offset, num_samples, num_channels,
+                       sample_rate, sample_type, bo);
+            break;
+        case wff_audlab:
+            return save_wave_audlab_data(fp, data, offset, num_samples, num_channels,
+                       sample_rate, sample_type, bo);
+            break;
+        case wff_snd:
+            return save_wave_snd_data(fp, data, offset, num_samples, num_channels,
+                       sample_rate, sample_type, bo);
+            break;
+        case wff_aiff:
+            return save_wave_aiff_data(fp, data, offset, num_samples, num_channels,
+                       sample_rate, sample_type, bo);
+            break;
+        case wff_riff:
+            return save_wave_riff_data(fp, data, offset, num_samples, num_channels,
+                       sample_rate, sample_type, bo);
+            break;
+        case wff_raw:
+            return save_wave_raw_data(fp, data, offset, num_samples, num_channels,
+                       sample_rate, sample_type, bo);
+            break;
+        case wff_ulaw:
+            return save_wave_ulaw_data(fp, data, offset, num_samples, num_channels,
+                       sample_rate, sample_type, bo);
+            break;
+        default:
+        case wff_none:
+            cerr << "Can't save wave data to files type " << ftype << endl;
+            break;
+    }
+    return write_ok;
+}

--- a/speech_class/waveP.h
+++ b/speech_class/waveP.h
@@ -42,16 +42,26 @@
 #include <stdio.h>
 
 /* The following three (raw, alaw and ulaw) cannot be in the table as they cannot */
-/* identify themselves from files (both are unheadered)                */
+/* identify themselves from files (all three are unheadered)                */
 enum EST_read_status load_wave_raw(EST_TokenStream &ts, short **data, int
 	 *num_samples, int *num_channels, int *word_size, int
 	 *sample_rate,  enum EST_sample_type_t *sample_type, int *bo, int
 	 offset, int length, int isample_rate, enum EST_sample_type_t
 	 isample_type, int ibo, int inc);
 enum EST_write_status save_wave_raw(FILE *fp, const short *data, int offset,
-			       int num_samples, int num_channels, 
-			       int sample_rate,
-			       enum EST_sample_type_t sample_type, int bo)   ;
+	 int num_samples, int num_channels, 
+	 int sample_rate,
+	 enum EST_sample_type_t sample_type, int bo);
+
+enum EST_write_status save_wave_raw_header(FILE *fp,
+				int num_samples, int num_channels,
+				int sample_rate,
+				enum EST_sample_type_t sample_type, int bo);
+
+enum EST_write_status save_wave_raw_data(FILE *fp, const short *data, int offset,
+				int num_samples, int num_channels,
+				int sample_rate,
+				enum EST_sample_type_t sample_type, int bo);
 
 enum EST_read_status load_wave_ulaw(EST_TokenStream &ts, short **data, int
 	 *num_samples, int *num_channels, int *word_size, int
@@ -62,6 +72,16 @@ enum EST_write_status save_wave_ulaw(FILE *fp, const short *data, int offset,
 				int sample_rate,
 				enum EST_sample_type_t, int bo);
 
+enum EST_write_status save_wave_ulaw_header(FILE *fp,
+				int num_samples, int num_channels,
+				int sample_rate,
+				enum EST_sample_type_t sample_type, int bo);
+
+enum EST_write_status save_wave_ulaw_data(FILE *fp, const short *data, int offset,
+				int num_samples, int num_channels,
+				int sample_rate,
+				enum EST_sample_type_t sample_type, int bo);
+
 enum EST_read_status load_wave_alaw(EST_TokenStream &ts, short **data, int
 	 *num_samples, int *num_channels, int *word_size, int
 	 *sample_rate,  enum EST_sample_type_t *sample_type, int *bo, int
@@ -70,6 +90,16 @@ enum EST_write_status save_wave_alaw(FILE *fp, const short *data, int offset,
 				int length, int num_channels, 
 				int sample_rate,
 				enum EST_sample_type_t, int bo);
+
+enum EST_write_status save_wave_alaw_header(FILE *fp,
+				int num_samples, int num_channels,
+				int sample_rate,
+				enum EST_sample_type_t sample_type, int bo);
+
+enum EST_write_status save_wave_alaw_data(FILE *fp, const short *data, int offset,
+				int num_samples, int num_channels,
+				int sample_rate,
+				enum EST_sample_type_t sample_type, int bo);
 
 enum EST_read_status load_wave_nist(EST_TokenStream &ts, short **data, int
 	 *num_samples, int *num_channels, int *word_size, int
@@ -81,6 +111,16 @@ enum EST_write_status save_wave_nist(FILE *fp, const short *data, int offset,
 			       int sample_rate,
 			       enum EST_sample_type_t sample_type, int bo);
 
+enum EST_write_status save_wave_nist_header(FILE *fp,
+				int num_samples, int num_channels,
+				int sample_rate,
+				enum EST_sample_type_t sample_type, int bo);
+
+enum EST_write_status save_wave_nist_data(FILE *fp, const short *data, int offset,
+				int num_samples, int num_channels,
+				int sample_rate,
+				enum EST_sample_type_t sample_type, int bo);
+
 enum EST_read_status load_wave_est(EST_TokenStream &ts, short **data, int
 	 *num_samples, int *num_channels, int *word_size, int
 	 *sample_rate,  enum EST_sample_type_t *sample_type, int *bo, int
@@ -90,6 +130,16 @@ enum EST_write_status save_wave_est(FILE *fp, const short *data, int offset,
 			       int num_samples, int num_channels, 
 			       int sample_rate,
 			       enum EST_sample_type_t sample_type, int bo);
+
+enum EST_write_status save_wave_est_header(FILE *fp,
+				int num_samples, int num_channels,
+				int sample_rate,
+				enum EST_sample_type_t sample_type, int bo);
+
+enum EST_write_status save_wave_est_data(FILE *fp, const short *data, int offset,
+				int num_samples, int num_channels,
+				int sample_rate,
+				enum EST_sample_type_t sample_type, int bo);
 
 enum EST_read_status load_wave_sd(EST_TokenStream &ts, short **data, int
 	 *num_samples, int *num_channels, int *word_size, int
@@ -101,6 +151,16 @@ enum EST_write_status save_wave_sd(FILE *fp, const short *data, int offset,
 			      int sample_rate, 
 			      enum EST_sample_type_t sample_type, int bo);
 
+enum EST_write_status save_wave_sd_header(FILE *fp,
+				int num_samples, int num_channels,
+				int sample_rate,
+				enum EST_sample_type_t sample_type, int bo);
+
+enum EST_write_status save_wave_sd_data(FILE *fp, const short *data, int offset,
+				int num_samples, int num_channels,
+				int sample_rate,
+				enum EST_sample_type_t sample_type, int bo);
+
 enum EST_read_status load_wave_audlab(EST_TokenStream &ts, short **data, int
 	 *num_samples, int *num_channels, int *word_size, int
 	 *sample_rate,  enum EST_sample_type_t *sample_type, int *bo, int
@@ -110,6 +170,16 @@ enum EST_write_status save_wave_audlab(FILE *fp, const short *data, int offset,
 			       int num_samples, int num_channels, 
 			       int sample_rate, 
 			       enum EST_sample_type_t sample_type, int bo);
+
+enum EST_write_status save_wave_audlab_header(FILE *fp,
+				int num_samples, int num_channels,
+				int sample_rate,
+				enum EST_sample_type_t sample_type, int bo);
+
+enum EST_write_status save_wave_audlab_data(FILE *fp, const short *data, int offset,
+				int num_samples, int num_channels,
+				int sample_rate,
+				enum EST_sample_type_t sample_type, int bo);
 
 enum EST_read_status load_wave_snd(EST_TokenStream &ts, short **data, int
 	 *num_samples, int *num_channels, int *word_size, int
@@ -121,6 +191,16 @@ enum EST_write_status save_wave_snd(FILE *fp, const short *data, int offset,
 			       int sample_rate, 
 			       enum EST_sample_type_t sample_type, int bo);
 
+enum EST_write_status save_wave_snd_header(FILE *fp,
+				int num_samples, int num_channels,
+				int sample_rate,
+				enum EST_sample_type_t sample_type, int bo);
+
+enum EST_write_status save_wave_snd_data(FILE *fp, const short *data, int offset,
+				int num_samples, int num_channels,
+				int sample_rate,
+				enum EST_sample_type_t sample_type, int bo);
+
 enum EST_read_status load_wave_aiff(EST_TokenStream &ts, short **data, int
 	 *num_samples, int *num_channels, int *word_size, int
 	 *sample_rate,  enum EST_sample_type_t *sample_type, int *bo, int
@@ -131,12 +211,32 @@ enum EST_write_status save_wave_aiff(FILE *fp, const short *data, int offset,
 				int sample_rate,
 				enum EST_sample_type_t sample_type, int bo);
 
+enum EST_write_status save_wave_aiff_header(FILE *fp,
+				int num_samples, int num_channels,
+				int sample_rate,
+				enum EST_sample_type_t sample_type, int bo);
+
+enum EST_write_status save_wave_aiff_data(FILE *fp, const short *data, int offset,
+				int num_samples, int num_channels,
+				int sample_rate,
+				enum EST_sample_type_t sample_type, int bo);
+
 enum EST_read_status load_wave_riff(EST_TokenStream &ts, short **data, int
 	 *num_samples, int *num_channels, int *word_size, int
 	 *sample_rate,  enum EST_sample_type_t *sample_type, int *bo, int
 	 offset, int length);
 
 enum EST_write_status save_wave_riff(FILE *fp, const short *data, int offset,
+				int num_samples, int num_channels, 
+				int sample_rate,
+				enum EST_sample_type_t sample_type, int bo);
+
+enum EST_write_status save_wave_riff_header(FILE *fp,
+				int num_samples, int num_channels,
+				int sample_rate,
+				enum EST_sample_type_t sample_type, int bo);
+
+enum EST_write_status save_wave_riff_data(FILE *fp, const short *data, int offset,
 				int num_samples, int num_channels, 
 				int sample_rate,
 				enum EST_sample_type_t sample_type, int bo);


### PR DESCRIPTION
This pull request adds methods to EST_Wave for saving wave files by parts.

Backwards compatibility is preserved.

It offers to write either only the file header or the actual data (or both).
Additionally it provides a function to write a wave file header without
having an EST_Wave instance.

This patch is ground work for festival improvements in text2wave
memory (and disk) usage on long texts.

This patch has been used in Debian since 2013.