### PR TITLE
Use the template of the class, not its parent

### DIFF
--- a/include/EST_TIterator.h
+++ b/include/EST_TIterator.h
@@ -203,7 +203,7 @@ class EST_TStructIterator
 {
 public:  
 
-  typedef EST_TIterator<Container, IPointer, Entry> Iter;
+  typedef EST_TStructIterator<Container, IPointer, Entry> Iter;
 
   /// Create an iterator not associated with any specific container.
   EST_TStructIterator() {this->cont=NULL;}
@@ -233,7 +233,7 @@ private:
 
 public:
 
-  typedef EST_TIterator<Container, IPointer, Entry> Iter;
+  typedef EST_TRwIterator<Container, IPointer, Entry> Iter;
 
   /// Create an iterator not associated with any specific container.
   EST_TRwIterator() {this->cont=NULL;}
@@ -283,7 +283,7 @@ class EST_TRwStructIterator
 {
 public:
 
-  typedef EST_TIterator<Container, IPointer, Entry> Iter;
+  typedef EST_TRwStructIterator<Container, IPointer, Entry> Iter;
 
   /// Create an iterator not associated with any specific container.
   EST_TRwStructIterator() {this->cont=NULL;}


### PR DESCRIPTION
Based on the Debian patch from https://salsa.debian.org/tts-team/speech-tools/-/blob/master/debian/patches/include_EST_TIterator.h.diff