### PR TITLE
Cosmetic change makes builds fully reproducible

### DIFF
--- a/config/rules/modules.sh
+++ b/config/rules/modules.sh
@@ -58,7 +58,6 @@ fi
 echo ' ###########################################################################'
 echo ' ## This file is created automatically from your config file.'
 echo ' ## Do not hand edit.'
-echo ' ## Created:'`date`
 echo ' ###########################################################################'
 
 echo ''

--- a/config/system.sh
+++ b/config/system.sh
@@ -102,7 +102,6 @@ fi
 echo ' ###########################################################################'
 echo ' ## This file is created automatically from your config file.'
 echo ' ## Do not hand edit.'
-echo ' ## Created:'`date`
 echo ' ###########################################################################'
 
 echo ''


### PR DESCRIPTION
The `date` command used in these two scripts may be convenient to some users, but it prevents the build to be 100% reproducible.

It's just a cosmetic issue on two text files, but the ReproducibleBuilds team in Debian [1] devoted the time to prepare a patch [2] just to workaround this date issue. I guess they would appreciate the patch to be considered for being merged.

[1] https://wiki.debian.org/ReproducibleBuilds/About
[2] https://salsa.debian.org/tts-team/speech-tools/-/blob/master/debian/patches/timestamp