### PR TITLE
Decouple ALSA and PulseAudio audio modules

### DIFF
--- a/audio/Makefile
+++ b/audio/Makefile
@@ -44,7 +44,7 @@ LOCAL_DEFAULT_LIBRARY = estbase
 H = audioP.h
 CPPSRCS = gen_audio.cc nas.cc esd.cc sun16audio.cc \
           mplayer.cc win32audio.cc irixaudio.cc os2audio.cc \
-          macosxaudio.cc linux_sound.cc
+          macosxaudio.cc pulseaudio.cc  linux_sound.cc
 
 SRCS = $(CPPSRCS)
 OBJS = $(SRCS:.cc=.o)
@@ -58,17 +58,4 @@ include $(TOP)/config/common_make_rules
 
 DEFINES += $(AUDIO_DEFINES)
 INCLUDES += $(AUDIO_INCLUDES)
-
-
-
-
-
-
-
-
-
-
-
-
-
 

--- a/audio/gen_audio.cc
+++ b/audio/gen_audio.cc
@@ -81,6 +81,8 @@ int play_wave(EST_Wave &inwave, EST_Option &al)
     {
 	if (nas_supported)
 	    protocol = "netaudio";  // the default protocol
+	else if (pulse_supported)
+	    protocol = "pulseaudio";
 	else if (esd_supported)
 	    protocol = "esdaudio";
 	else if (sun16_supported)
@@ -112,6 +114,8 @@ int play_wave(EST_Wave &inwave, EST_Option &al)
 
     if (upcase(protocol) == "NETAUDIO")
 	return play_nas_wave(*toplay,al);
+    else if (upcase(protocol) == "PULSEAUDIO")
+	return play_pulse_wave(*toplay,al);
     else if (upcase(protocol) == "ESDAUDIO")
 	return play_esd_wave(*toplay,al);
     else if (upcase(protocol) == "SUNAUDIO")
@@ -246,6 +250,8 @@ EST_String options_supported_audio(void)
     audios += " audio_command";
     if (nas_supported)
 	audios += " netaudio";
+    else if (pulse_supported)
+	audios += " pulseaudio";
     else if (esd_supported)
 	audios += " esdaudio";
     if (sun16_supported)
@@ -288,6 +294,8 @@ int record_wave(EST_Wave &wave, EST_Option &al)
     {
 	if (nas_supported)
 	    protocol = "netaudio";  // the default protocol
+	else if (pulse_supported)
+	    protocol = "pulseaudio";  // the default protocol
 	else if (esd_supported)
 	    protocol = "esdaudio";  // the default protocol
 	else if (sun16_supported)
@@ -308,6 +316,8 @@ int record_wave(EST_Wave &wave, EST_Option &al)
 
     if (upcase(protocol) == "NETAUDIO")
 	return record_nas_wave(wave,al);
+    else if (upcase(protocol) == "PULSEAUDIO")
+        return record_pulse_wave(wave,al);
     else if (upcase(protocol) == "ESDAUDIO")
         return record_esd_wave(wave,al);
     else if (upcase(protocol) == "SUN16AUDIO")

--- a/audio/linux_sound.cc
+++ b/audio/linux_sound.cc
@@ -869,72 +869,6 @@ int record_linux_wave(EST_Wave &inwave, EST_Option &al)
 
 #else
 
-#ifdef SUPPORT_PULSEAUDIO
-#include <pulse/simple.h>
-
-int freebsd16_supported = FALSE;
-int linux16_supported = TRUE;
-
-static const char *aud_sys_name = "PULSEAUDIO";
-
-#define AUDIOBUFFSIZE 256
-// #define AUDIOBUFFSIZE 20480
-
-int play_linux_wave(EST_Wave &inwave, EST_Option &al)
-{
-    pa_sample_spec *ss;
-    pa_simple *s;
-    short *waveform;
-    int num_samples;
-    int err=0, i, r;
-
-    ss = walloc(pa_sample_spec,1);
-    ss->rate = inwave.sample_rate();
-    ss->channels = inwave.num_channels();
-
-    if (EST_BIG_ENDIAN)
-        ss->format = PA_SAMPLE_S16BE;
-    else
-        ss->format = PA_SAMPLE_S16LE;
-    
-    s = pa_simple_new(
-                    NULL,      /* use default server */
-                    "festival",
-                    PA_STREAM_PLAYBACK,
-                    NULL,      /* use default device */
-                    "Speech",
-                    ss,
-                    NULL,      /* default channel map */
-                    NULL,      /* default buffering attributes */
-                    &err);
-    if (err < 0)
-        return NULL;
-
-    waveform = inwave.values().memory();
-    num_samples = inwave.num_samples();
-
-    for (i=0; i < num_samples; i += AUDIOBUFFSIZE/2)
-    {
-        if (i + AUDIOBUFFSIZE/2 < num_samples)
-            pa_simple_write(s,&waveform[i],(size_t)AUDIOBUFFSIZE,&err);
-        else
-            pa_simple_write(s,&waveform[i],(size_t)(num_samples-i)*2,&err);
-    }
-
-    pa_simple_drain(s,&err);
-    pa_simple_free(s);
-    wfree(ss);
-
-    return 1;
-}
-
-int record_linux_wave(EST_Wave &inwave, EST_Option &al)
-{
-    return -1;
-}
-
-#else /* not supported */
-
 int freebsd16_supported = FALSE;
 int linux16_supported = FALSE;
 
@@ -954,6 +888,5 @@ int record_linux_wave(EST_Wave &inwave, EST_Option &al)
 }
 
 #endif /* ALSA */
-#endif /* PULSEAUDIO */
 #endif /* VOXWARE */
 

--- a/audio/pulseaudio.cc
+++ b/audio/pulseaudio.cc
@@ -2,7 +2,9 @@
 /*                                                                       */
 /*                Centre for Speech Technology Research                  */
 /*                     University of Edinburgh, UK                       */
-/*                         Copyright (c) 1996                            */
+/*                      Copyright (c) 1997,1998                          */
+/*                            Red Hat, Inc.                              */
+/*                         Copyright (c) 2008                            */
 /*                        All Rights Reserved.                           */
 /*                                                                       */
 /*  Permission is hereby granted, free of charge, to use and distribute  */
@@ -30,29 +32,92 @@
 /*  THIS SOFTWARE.                                                       */
 /*                                                                       */
 /*************************************************************************/
-/*                       Author :  Alan W Black                          */
-/*                       Date   :  May 1996                              */
+/*  Optional support for PulseAudio                                      */
 /*=======================================================================*/
-/*                 Shared (private) audio declarations                   */
-/*                                                                       */
-/*=======================================================================*/
-#ifndef __AUDIOP_H__
-#define __AUDIOP_H__
 
-int play_nas_wave(EST_Wave &inwave, EST_Option &al);
-int play_pulse_wave(EST_Wave &inwave, EST_Option &al);
-int play_esd_wave(EST_Wave &inwave, EST_Option &al);
-int play_sun16_wave(EST_Wave &inwave, EST_Option &al);
-int play_linux_wave(EST_Wave &inwave, EST_Option &al);
-int play_mplayer_wave(EST_Wave &inwave, EST_Option &al);
-int play_win32audio_wave(EST_Wave &inwave, EST_Option &al);
-int play_irix_wave(EST_Wave &inwave, EST_Option &al);
-int play_macosx_wave(EST_Wave &inwave, EST_Option &al);
+#include "EST_Wave.h"
+#include "EST_Option.h"
+#include "audioP.h"
 
-int record_nas_wave(EST_Wave &inwave, EST_Option &al);
-int record_pulse_wave(EST_Wave &inwave, EST_Option &al);
-int record_esd_wave(EST_Wave &inwave, EST_Option &al);
-int record_sun16_wave(EST_Wave &inwave, EST_Option &al);
-int record_linux_wave(EST_Wave &inwave, EST_Option &al);
+using namespace std;
 
-#endif /* __AUDIOP_H__ */
+#ifdef SUPPORT_PULSEAUDIO
+
+#include <pulse/simple.h>
+int pulse_supported = TRUE;
+
+#define AUDIOBUFFSIZE 256
+// #define AUDIOBUFFSIZE 20480
+
+int play_pulse_wave(EST_Wave &inwave, EST_Option &al)
+{
+    pa_sample_spec *ss;
+    pa_simple *s;
+    short *waveform;
+    int num_samples;
+    int err=0, i;
+
+    ss = walloc(pa_sample_spec,1);
+    ss->rate = inwave.sample_rate();
+    ss->channels = inwave.num_channels();
+
+    ss->format = PA_SAMPLE_S16NE;
+    
+    s = pa_simple_new(
+                    NULL,      /* use default server */
+                    "festival",
+                    PA_STREAM_PLAYBACK,
+                    NULL,      /* use default device */
+                    "Speech",
+                    ss,
+                    NULL,      /* default channel map */
+                    NULL,      /* default buffering attributes */
+                    &err);
+    if (err < 0)
+        return 0;
+
+    waveform = inwave.values().memory();
+    num_samples = inwave.num_samples();
+
+    for (i=0; i < num_samples; i += AUDIOBUFFSIZE/2)
+    {
+        if (i + AUDIOBUFFSIZE/2 < num_samples)
+            pa_simple_write(s,&waveform[i],(size_t)AUDIOBUFFSIZE,&err);
+        else
+            pa_simple_write(s,&waveform[i],(size_t)(num_samples-i)*2,&err);
+    }
+
+    pa_simple_drain(s,&err);
+    pa_simple_free(s);
+    wfree(ss);
+
+    return 1;
+}
+
+int record_pulse_wave(EST_Wave &inwave, EST_Option &al)
+{
+    return -1;
+}
+
+#else /* SUPPORT_PULSEAUDIO */
+
+int pulse_supported = FALSE;
+
+int play_pulse_wave(EST_Wave &inwave, EST_Option &al)
+{
+    (void)inwave;
+    (void)al;
+    cerr << "Audio: pulseaudio not compiled in this version" << endl;
+    return -1;
+}
+
+int record_pulse_wave(EST_Wave &inwave, EST_Option &al)
+{
+    (void)inwave;
+    (void)al;
+    cerr << "Audio: pulseaudio not compiled in this version" << endl;
+    return -1;
+}
+
+
+#endif /* SUPPORT_PULSEAUDIO */

--- a/config/config.in
+++ b/config/config.in
@@ -82,6 +82,9 @@ OPTIMISE_sigpr = 3
 ## Elightenment Sound Demon, for KDE etc.
 # INCLUDE_MODULES += ESD_AUDIO
 
+## PulseAudio sound server. Write PULSE_AUDIO to include it.
+INCLUDE_MODULES += @PULSE_AUDIO@
+
 ## Native audio for your platform (sun, linux, freebsd, irix, macosx, windows)
 INCLUDE_MODULES += NATIVE_AUDIO
 

--- a/config/modules/linux16_audio.mak
+++ b/config/modules/linux16_audio.mak
@@ -50,13 +50,6 @@ ifeq ($(LINUXAUDIO),alsa)
    PROJECT_LIBRARY_SYSLIBS_estbase += -lasound
 endif
 
-ifeq ($(LINUXAUDIO),pulseaudio)
-   AUDIO_DEFINES += -DSUPPORT_PULSEAUDIO
-   MODULE_LIBS += -lpulse-simple -lpulse
-
-   PROJECT_LIBRARY_SYSLIBS_estbase += -lpulse-simple -lpulse
-endif
-
 ifeq ($(LINUXAUDIO),none)
    AUDIO_DEFINES += -DSUPPORT_VOXWARE
 endif

--- a/config/modules/pulse_audio.mak
+++ b/config/modules/pulse_audio.mak
@@ -1,0 +1,11 @@
+## Definitions for PulseAudio
+
+INCLUDE_PULSE_AUDIO=1
+
+MOD_DESC_PULSE_AUDIO=PulseAudio support
+
+AUDIO_DEFINES += -DSUPPORT_PULSEAUDIO
+AUDIO_INCLUDES += -I$(PULSE_INCLUDE)
+MODULE_LIBS += -lpulse-simple -lpulse
+PROJECT_LIBRARY_SYSLIBS_estbase += -lpulse-simple -lpulse
+

--- a/configure
+++ b/configure
@@ -623,6 +623,7 @@ ac_subst_vars='LTLIBOBJS
 LIBOBJS
 OMP_DEFS
 OMP_OPTS
+PULSE_AUDIO
 LINUXAUDIO
 DEBUG
 SHARED
@@ -697,6 +698,7 @@ SHELL'
 ac_subst_files=''
 ac_user_opts='
 enable_option_checking
+with_pulseaudio
 '
       ac_precious_vars='build_alias
 host_alias
@@ -1331,6 +1333,11 @@ fi
 if test -n "$ac_init_help"; then
 
   cat <<\_ACEOF
+
+Optional Packages:
+  --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
+  --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
+  --with-pulseaudio       Compile PulseAudio audio module [default=no]
 
 Some influential environment variables:
   CXX         C++ compiler command
@@ -4294,6 +4301,23 @@ if test "x$ac_cv_header_alsa_asoundlib_h" = xyes; then :
   LINUXAUDIO="alsa"
 fi
 
+
+
+
+
+# Check whether --with-pulseaudio was given.
+if test "${with_pulseaudio+set}" = set; then :
+  withval=$with_pulseaudio;
+else
+  with_pulseaudio=no
+fi
+
+
+
+PULSE_AUDIO=
+if test "x$with_pulseaudio" != xno; then :
+  PULSE_AUDIO="PULSE_AUDIO"
+fi
 
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -109,6 +109,21 @@ AC_CHECK_HEADER(alsa/asoundlib.h,
               [LINUXAUDIO="alsa"])
 AC_SUBST(LINUXAUDIO)
 
+AC_ARG_WITH([pulseaudio],
+  [AS_HELP_STRING([--with-pulseaudio],
+  [Compile PulseAudio audio module @<:@default=no@:>@])],
+  [],
+  [with_pulseaudio=no])
+
+
+PULSE_AUDIO=
+AS_IF([test "x$with_pulseaudio" != xno],
+      [PULSE_AUDIO="PULSE_AUDIO"],
+      []
+)
+
+AC_SUBST(PULSE_AUDIO)
+
 OMP_OPTS=
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <omp.h>]], [[ int j=1;]])],[OMP_OPTS="-fopenmp"],[])
 AC_SUBST(OMP_OPTS)

--- a/include/EST_audio.h
+++ b/include/EST_audio.h
@@ -43,6 +43,7 @@
 #include "EST_Option.h"
 
 extern int nas_supported;
+extern int pulse_supported;
 extern int esd_supported;
 extern int sun16_supported;
 extern int freebsd16_supported;


### PR DESCRIPTION
On Debian (and other distributions), the package maintainers need to compile both ALSA and PulseAudio support, so users can choose the audio module they prefer. Before this PR, speech-tools is built with either ALSA or PulseAudio support, but not both. With this pull request, PulseAudio becomes an independent audio module (like esdaudio).

This PR is improved from https://salsa.debian.org/tts-team/speech-tools/-/blob/master/debian/patches/pulseaudio_and_alsa.diff