### PR TITLE
Fix regression from #31

### DIFF
--- a/include/EST_TIterator.h
+++ b/include/EST_TIterator.h
@@ -209,7 +209,7 @@ public:
   EST_TStructIterator() {this->cont=NULL;}
 
   /// Copy an iterator by assignment
-  Iter &operator = (const Iter &orig)
+  Iter &operator = (const EST_TIterator<Container, IPointer, Entry> &orig)
     { this->cont=orig.cont; this->pos=orig.pos; this->pointer=orig.pointer; return *this;}
 
   /// Create an iterator ready to run over the given container.
@@ -239,7 +239,7 @@ public:
   EST_TRwIterator() {this->cont=NULL;}
 
   /// Copy an iterator by assignment
-  Iter &operator = (const Iter &orig)
+  Iter &operator = (const EST_TIterator<Container, IPointer, Entry> &orig)
     { this->cont=orig.cont; this->pos=orig.pos; this->pointer=orig.pointer; return *this;}
 
   /// Create an iterator ready to run over the given container.
@@ -289,7 +289,7 @@ public:
   EST_TRwStructIterator() {this->cont=NULL;}
 
   /// Copy an iterator by assignment
-  Iter &operator = (const Iter &orig)
+  Iter &operator = (const EST_TIterator<Container, IPointer, Entry> &orig)
     { this->cont=orig.cont; this->pos=orig.pos; this->pointer=orig.pointer; return *this;}
 
   /// Create an iterator ready to run over the given container.


### PR DESCRIPTION
This PR fixes a regression introduced in fb9a7fc54a0cd9597bfc3d9c85a8ac6422c03f6f

The assignment operator of the derived iterators should accept any `EST_TIterator`, since they are all compatible, and not only the Iterator of the exact same derived class.

Unless some other regression appears, I don't think I will have more PR to speech-tools. I'll focus on Festival next. Thanks for all the review process.