### PR TITLE
Fix: Minor fixes 2 (Add "using namespace" to compilation units)

### DIFF
--- a/audio/gen_audio.cc
+++ b/audio/gen_audio.cc
@@ -51,6 +51,8 @@
 #include "EST_audio.h"
 #include "EST_wave_aux.h"
 
+using namespace std;
+
 static int play_sunau_wave(EST_Wave &inwave, EST_Option &al);
 static int play_socket_wave(EST_Wave &inwave, EST_Option &al);
 static int play_aucomm_wave(EST_Wave &inwave, EST_Option &al);

--- a/audio/irixaudio.cc
+++ b/audio/irixaudio.cc
@@ -17,6 +17,8 @@
 #include "audioP.h"
 #include "EST_io_aux.h"
 
+using namespace std;
+
 #if defined (SUPPORT_IRIX) || defined (SUPPORT_IRIX53)
 #include <audio.h>
 #include <unistd.h>

--- a/audio/linux_sound.cc
+++ b/audio/linux_sound.cc
@@ -60,6 +60,8 @@
 #include "EST_io_aux.h"
 #include "EST_error.h"
 
+using namespace std;
+
 #ifdef SUPPORT_FREEBSD16
 #include <sys/soundcard.h>
 #include <fcntl.h>

--- a/audio/macosxaudio.cc
+++ b/audio/macosxaudio.cc
@@ -45,6 +45,8 @@
 #include "EST_Option.h"
 #include "audioP.h"
 
+using namespace std;
+
 #if defined (SUPPORT_MACOSX_AUDIO)
 
 #include <CoreServices/CoreServices.h>

--- a/audio/mplayer.cc
+++ b/audio/mplayer.cc
@@ -44,6 +44,8 @@
 #include "EST_io_aux.h"
 #include "EST_Pathname.h"
 
+using namespace std;
+
 #ifdef SUPPORT_MPLAYER
 
 int mplayer_supported = TRUE;

--- a/audio/nas.cc
+++ b/audio/nas.cc
@@ -47,6 +47,9 @@
 #include "audioP.h"
 #include "EST_io_aux.h"
 
+using namespace std;
+
+
 #ifdef SUPPORT_NAS
 #include <audio/audiolib.h>
 #include <audio/soundlib.h>

--- a/audio/os2audio.cc
+++ b/audio/os2audio.cc
@@ -260,7 +260,7 @@ int play_os2audio_wave(EST_Wave &inwave, EST_Option &al)
 {
     (void)inwave;
     (void)al;
-    cerr << "OS/2 16bit realtime DART playback not supported." << endl;
+    std::cerr << "OS/2 16bit realtime DART playback not supported." << std::endl;
     return -1;
 }
 

--- a/audio/sun16audio.cc
+++ b/audio/sun16audio.cc
@@ -56,6 +56,8 @@
 #include "EST_io_aux.h"
 #include "EST_unix.h"
 
+using namespace std;
+
 #ifdef SUPPORT_SUN16
 #include <sys/filio.h>
 #if defined(__svr4__) || defined(SYSV) || defined(SVR4)

--- a/audio/win32audio.cc
+++ b/audio/win32audio.cc
@@ -44,6 +44,8 @@
 #include "EST_io_aux.h"
 #include "EST_Pathname.h"
 
+using namespace std;
+
 #ifdef SUPPORT_WIN32AUDIO
 
 #include <EST_system.h>

--- a/base_class/EST_DMatrix.cc
+++ b/base_class/EST_DMatrix.cc
@@ -52,6 +52,8 @@
 #include "EST_Token.h"
 #include "rateconv.h"
 
+using namespace std;
+
 EST_String EST_DMatrix::default_file_type = "est_ascii";
 
 EST_DMatrix::EST_DMatrix(const EST_DMatrix &a, int b)

--- a/base_class/EST_FeatureData.cc
+++ b/base_class/EST_FeatureData.cc
@@ -50,6 +50,7 @@
 
 #include "EST_THash.h"
 
+using namespace std;
 
 EST_FeatureData::EST_FeatureData()
 {

--- a/base_class/EST_Option.cc
+++ b/base_class/EST_Option.cc
@@ -42,6 +42,12 @@
 #include "EST_io_aux.h"
 #include "EST_Token.h"
 
+#include <iostream>
+using std::cin;
+using std::cout;
+using std::cerr;
+using std::endl;
+
 static const EST_String Empty_String("");
 
 // Fills in keyval pair. If Key already exists, overwrites value.

--- a/base_class/EST_THash.cc
+++ b/base_class/EST_THash.cc
@@ -213,7 +213,7 @@ int EST_THash<K,V>::remove_item(const K &rkey, int quiet)
       }
       
   if (!quiet)
-    cerr << "THash: no item labelled \"" << rkey << "\"" << endl;
+    std::cerr << "THash: no item labelled \"" << rkey << "\"" << std::endl;
   return -1;
 }
 

--- a/base_class/EST_TList.cc
+++ b/base_class/EST_TList.cc
@@ -109,7 +109,7 @@ template<class T> EST_TList<T> &EST_TList<T>::operator+=(const EST_TList<T> &a)
 {
     if (this == &a)
     {
-	cerr << "EST_TList: error: tried to add list to itself\n";
+	std::cerr << "EST_TList: error: tried to add list to itself\n";
 	return *this;
     }
     copy_items(a);

--- a/base_class/EST_TNamedEnum.cc
+++ b/base_class/EST_TNamedEnum.cc
@@ -141,7 +141,7 @@ INFO &EST_TValuedEnumI<ENUM,VAL,INFO>::info (ENUM token) const
     if (this->definitions[i].token == token)
       return this->definitions[i].info;
 
-  cerr << "Fetching info for invalid entry\n";
+  std::cerr << "Fetching info for invalid entry" << std::endl;
   abort();
 
   static INFO dummyI;
@@ -198,7 +198,7 @@ EST_read_status EST_TNamedEnum<ENUM>::priv_load(EST_String name, EST_TNamedEnum<
     {
       if ( buffer[LINE_LENGTH-1] != 'x')
 	{
-	  cerr << "line too long .. '" << buffer << "'\n";
+	  std::cerr << "line too long .. '" << buffer << "'\n";
 	  return wrong_format;
 	}
 
@@ -208,7 +208,7 @@ EST_read_status EST_TNamedEnum<ENUM>::priv_load(EST_String name, EST_TNamedEnum<
 
 	  if ( n>= this->ndefinitions)
 	    {
-	      cerr << "too many definitions\n";
+	      std::cerr << "too many definitions\n";
 	      return wrong_format;
 	    }
 
@@ -227,12 +227,12 @@ EST_read_status EST_TNamedEnum<ENUM>::priv_load(EST_String name, EST_TNamedEnum<
 	  // definition by standard name
 	  if (!definitive)
 	    {
-	      cerr << "can't use names in this definition\n";
+	      std::cerr << "can't use names in this definition\n";
 	      return wrong_format;
 	    }
 	  if ( n>= this->ndefinitions)
 	    {
-	      cerr << "too many definitions\n";
+	      std::cerr << "too many definitions\n";
 	      return wrong_format;
 	    }
 
@@ -256,7 +256,7 @@ EST_read_status EST_TNamedEnum<ENUM>::priv_load(EST_String name, EST_TNamedEnum<
 
 	  if (eq <0)
 	    {
-	      cerr << "bad header line '" << line;
+	      std::cerr << "bad header line '" << line;
 	      return wrong_format;
 	    }
 
@@ -284,7 +284,7 @@ EST_read_status EST_TNamedEnum<ENUM>::priv_load(EST_String name, EST_TNamedEnum<
 	    }
 	  else
 	    {
-	      cerr << "bad header line '" << line;
+	      std::cerr << "bad header line '" << line;
 	      return wrong_format;
 	    }
 	  

--- a/base_class/EST_Token.cc
+++ b/base_class/EST_Token.cc
@@ -50,6 +50,8 @@
 #include "EST_cutils.h"
 #include "EST_error.h"
 
+using namespace std;
+
 const EST_String EST_Token_Default_WhiteSpaceChars = " \t\n\r";
 const EST_String EST_Token_Default_SingleCharSymbols = "(){}[]";
 const EST_String EST_Token_Default_PrePunctuationSymbols = "\"'`({[";
@@ -246,7 +248,7 @@ int EST_TokenStream::open(FILE *ofp, int close_when_finished)
     return 0;
 }
 
-int EST_TokenStream::open(istream &newis)
+int EST_TokenStream::open(std::istream &newis)
 {
     // absorb already open istream 
     if (type != tst_none)

--- a/base_class/EST_UList.cc
+++ b/base_class/EST_UList.cc
@@ -37,6 +37,8 @@
 /*************************************************************************/
 #include <EST_UList.h>
 
+using namespace std;
+
 void EST_UList::clear_and_free(void (*item_free)(EST_UItem *p))
 {
     EST_UItem *q, *np;

--- a/base_class/EST_features_aux.cc
+++ b/base_class/EST_features_aux.cc
@@ -44,6 +44,8 @@
 
 #include "EST_get_function_template.h"
 
+using namespace std;
+
 defineGetFunction(EST_Features, val, EST_Val, getVal)
 defineGetFunction(EST_Features, val, EST_String, getString)
 defineGetFunction(EST_Features, val, float, getFloat)

--- a/base_class/EST_features_io.cc
+++ b/base_class/EST_features_io.cc
@@ -43,6 +43,8 @@
 #include "EST_String.h"
 #include "EST_Token.h"
 
+using namespace std;
+
 void EST_Features::set_function(const EST_String &name, 
 			        const EST_String &funcname)
 {

--- a/base_class/EST_matrix_support.cc
+++ b/base_class/EST_matrix_support.cc
@@ -45,6 +45,8 @@
 
 const int EST_CURRENT=-1;
 const int EST_ALL=-1;
+using namespace std;
+
 
 bool EST_matrix_bounds_check(int r,
 			     int c,

--- a/base_class/EST_slist_aux.cc
+++ b/base_class/EST_slist_aux.cc
@@ -50,6 +50,8 @@
 #include "EST_cutils.h"
 #include "EST_Token.h"
 
+using namespace std;
+
 int StrListtoFList(EST_StrList &s, EST_FList &f)
 {
     EST_Litem *p;

--- a/base_class/EST_svec_aux.cc
+++ b/base_class/EST_svec_aux.cc
@@ -49,6 +49,8 @@
 #include "EST_cutils.h"
 #include "EST_Token.h"
 
+using namespace std;
+
 EST_read_status load_TList_of_StrVector(EST_TList<EST_StrVector> &w,
 					const EST_String &filename,
 					const int vec_len)

--- a/base_class/inst_tmpl/vector_f_t.cc
+++ b/base_class/inst_tmpl/vector_f_t.cc
@@ -69,9 +69,9 @@ EST_write_status save(const EST_String &filename, const EST_TVector<float> &a)
     {
       *outf << a(i) << "\t";
     }
-    *outf << endl;
+    *outf << std::endl;
     
-    if (outf != &cout)
+    if (outf != &std::cout)
 	delete outf;
     return write_ok;
 }

--- a/base_class/string/EST_Chunk.cc
+++ b/base_class/string/EST_Chunk.cc
@@ -45,6 +45,8 @@
 #include <cstring>
 #include "EST_Chunk.h"
 
+using namespace std;
+
 EST_Chunk::EST_Chunk ()
 {
   count = 0;

--- a/base_class/string/EST_Regex.cc
+++ b/base_class/string/EST_Regex.cc
@@ -59,6 +59,8 @@
 #include "EST_String.h"
 #include "EST_Regex.h"
 
+using namespace std;
+
 #ifdef sun
 #ifndef __svr4__
 /* SunOS */

--- a/base_class/vec_mat_aux.cc
+++ b/base_class/vec_mat_aux.cc
@@ -44,6 +44,8 @@
 #include "EST_math.h"
 #include <ctime>
 
+using namespace std;
+
 bool polynomial_fit(EST_FVector &x, EST_FVector &y, 
 		    EST_FVector &co_effs, int order)
 {
@@ -60,7 +62,7 @@ bool polynomial_fit(EST_FVector &x, EST_FVector &y, EST_FVector &co_effs,
 {
 
     if(order <= 0){
-	cerr << "polynomial_fit : order must be >= 1" << endl;
+	std::cerr << "polynomial_fit : order must be >= 1" << std::endl;
 	return false;
     }
 

--- a/base_class/vec_mat_aux_d.cc
+++ b/base_class/vec_mat_aux_d.cc
@@ -42,6 +42,8 @@
 #include "EST_math.h"
 #include "EST_unix.h"
 
+using namespace std;
+
 bool polynomial_fit(EST_DVector &x, EST_DVector &y, 
 		    EST_DVector &co_effs, int order)
 {

--- a/base_class/vec_mat_aux_i.cc
+++ b/base_class/vec_mat_aux_i.cc
@@ -44,6 +44,8 @@
 #include "EST_math.h"
 #include <time.h>
 
+using namespace std;
+
 int matrix_max(const EST_IMatrix &a)
 {
     int i, j;

--- a/grammar/ngram/EST_PST.cc
+++ b/grammar/ngram/EST_PST.cc
@@ -48,6 +48,8 @@
 #include "EST_PST.h"
 #include "EST_multistats.h"
 
+using namespace std;
+
 VAL_REGISTER_CLASS(pstnode,EST_PredictionSuffixTree_tree_node)
 
 // Out of vocabulary identifier

--- a/grammar/ngram/EST_lattice.cc
+++ b/grammar/ngram/EST_lattice.cc
@@ -41,6 +41,8 @@
 #include <fstream>
 #include <cstdlib>
 
+using namespace std;
+
 Lattice::Lattice()
 {
     tf=0;

--- a/grammar/ngram/EST_lattice_io.cc
+++ b/grammar/ngram/EST_lattice_io.cc
@@ -44,6 +44,8 @@
 #include "EST_Token.h"
 #include "EST_StringTrie.h"
 
+using namespace std;
+
 bool save(Lattice &lattice, EST_String filename)
 {
     ostream *outf;

--- a/grammar/ngram/freqsmooth.cc
+++ b/grammar/ngram/freqsmooth.cc
@@ -49,6 +49,8 @@
 #include <cfloat>
 #include "EST_Ngrammar.h"
 
+using namespace std;
+
 static double fs_find_backoff_prob(EST_Ngrammar *backoff_ngrams,
 				       int order,const EST_StrVector words,
 				       int smooth_thresh);

--- a/grammar/ngram/ngrammar_aux.cc
+++ b/grammar/ngram/ngrammar_aux.cc
@@ -42,6 +42,8 @@
 #include "EST_String.h"
 #include "EST_Ngrammar.h"
 
+using namespace std;
+
 static bool
 ExponentialFit(EST_DVector &N, double &a, double &b, int first, int last)
 {

--- a/grammar/ngram/ngrammar_io.cc
+++ b/grammar/ngram/ngrammar_io.cc
@@ -50,6 +50,8 @@
 #include "EST_Token.h"
 #include "EST_cutils.h"
 
+using namespace std;
+
 EST_read_status
 load_ngram_htk_ascii(const EST_String filename, EST_Ngrammar &n)
 {

--- a/grammar/ngram/ngrammar_utils.cc
+++ b/grammar/ngram/ngrammar_utils.cc
@@ -44,6 +44,8 @@
 #include "EST_error.h"
 #include "EST_Ngrammar.h"
 
+using namespace std;
+
 static int get_next_window(EST_TokenStream &ts,
 			   EST_StrVector &window,
 			   const EST_String &input_format,

--- a/grammar/scfg/EST_SCFG.cc
+++ b/grammar/scfg/EST_SCFG.cc
@@ -41,6 +41,8 @@
 #include "EST_Pathname.h"
 #include "EST_SCFG.h"
 
+using namespace std;
+
 EST_SCFG_Rule::EST_SCFG_Rule(double prob,int p, int m)
 { 
     set_rule(prob,p,m); 

--- a/grammar/scfg/EST_SCFG_Chart.cc
+++ b/grammar/scfg/EST_SCFG_Chart.cc
@@ -43,6 +43,8 @@
 #include "EST_SCFG.h"
 #include "EST_SCFG_Chart.h"
 
+using namespace std;
+
 EST_SCFG_Chart_Edge::EST_SCFG_Chart_Edge()
 {
     p_d1 = 0;

--- a/grammar/scfg/EST_SCFG_inout.cc
+++ b/grammar/scfg/EST_SCFG_inout.cc
@@ -64,6 +64,8 @@ template <> EST_bracketed_string *EST_TVector<EST_bracketed_string>::error_retur
 template class EST_TVector<EST_bracketed_string>;
 #endif
 
+using namespace std;
+
 void set_corpus(EST_Bcorpus &b, LISP examples)
 {
     LISP e;

--- a/grammar/wfst/EST_WFST.cc
+++ b/grammar/wfst/EST_WFST.cc
@@ -66,6 +66,8 @@ Instantiate_TVector_T(EST_WFST_State *, EST_WFST_StateP)
 
 #endif
 
+using namespace std;
+
 // Used for marking states duration traversing functions
 int EST_WFST::traverse_tag = 0;
 

--- a/grammar/wfst/kkcompile.cc
+++ b/grammar/wfst/kkcompile.cc
@@ -43,6 +43,8 @@
 #include "EST_WFST.h"
 #include "EST_cutils.h"
 
+using namespace std;
+
 ostream &operator << (ostream &s, const EST_WFST &w)
 {
   (void)w;

--- a/grammar/wfst/ltscompile.cc
+++ b/grammar/wfst/ltscompile.cc
@@ -44,6 +44,8 @@
 #include "EST_cutils.h"
 #include "EST_WFST.h"
 
+using namespace std;
+
 static LISP lts_find_feasible_pairs(LISP rules);
 static LISP make_fp(LISP in, LISP out);
 static LISP find_outs(LISP rule);

--- a/grammar/wfst/rgcompile.cc
+++ b/grammar/wfst/rgcompile.cc
@@ -46,6 +46,8 @@
 #include "EST_cutils.h"
 #include "EST_WFST.h"
 
+using namespace std;
+
 static LISP find_rewrites(LISP rules, LISP terms, LISP nonterms);
 static LISP rg_find_nt_ts(LISP rules,LISP sets);
 static LISP prod_join(LISP n, LISP p);

--- a/grammar/wfst/wfst_ops.cc
+++ b/grammar/wfst/wfst_ops.cc
@@ -47,6 +47,8 @@
 #include "EST_TKVL.h"
 #include "EST_THash.h"
 
+using namespace std;
+
 Declare_TList_T(EST_WFST_MultiState *,EST_WFST_MultiStateP)
 
   // Declare_KVL(int, EST_IList)

--- a/grammar/wfst/wfst_regex.cc
+++ b/grammar/wfst/wfst_regex.cc
@@ -41,6 +41,8 @@
 #include "EST_cutils.h"
 #include "EST_WFST.h"
 
+using namespace std;
+
 void EST_WFST::build_or_transition(int start, int end, LISP disjunctions)
 {
     // Choice of either disjunct

--- a/grammar/wfst/wfst_train.cc
+++ b/grammar/wfst/wfst_train.cc
@@ -48,6 +48,8 @@
 #include "EST_Token.h"
 #include "EST_simplestats.h"
 
+using namespace std;
+
 VAL_REGISTER_TYPE_NODEL(trans,EST_WFST_Transition)
 SIOD_REGISTER_CLASS(trans,EST_WFST_Transition)
 VAL_REGISTER_CLASS(pdf,EST_DiscreteProbDistribution)

--- a/grammar/wfst/wfst_transduce.cc
+++ b/grammar/wfst/wfst_transduce.cc
@@ -40,6 +40,8 @@
 #include <iostream>
 #include "EST_WFST.h"
 
+using namespace std;
+
 /** An internal class in transduction of WFSTs holding intermediate
     state information.
 */

--- a/include/EST.h
+++ b/include/EST.h
@@ -61,7 +61,7 @@
 #include "EST_system.h"
 #include <cstdlib>
 
-using namespace std;
+using namespace std; // FIXME: To be removed
 
 #include "EST_String.h"
 #include "EST_string_aux.h"

--- a/include/EST_Chunk.h
+++ b/include/EST_Chunk.h
@@ -46,7 +46,7 @@
 #define HAVE_WALLOC_H (1)
 
 #include <iostream>
-using namespace std;
+using namespace std; // FIXME: To be removed
 #include <climits>
 #include <sys/types.h>
 

--- a/include/EST_Complex.h
+++ b/include/EST_Complex.h
@@ -42,7 +42,7 @@
 
 #include <iostream>
 #include <cmath>
-using namespace std;
+using namespace std; // FIXME: To be removed
 
 
 #ifndef PI
@@ -104,7 +104,7 @@ friend EST_Complex operator / (const EST_Complex &z, float x);
 friend EST_Complex operator / (float x, const EST_Complex &z);
 
 
-friend ostream& operator<< (ostream& s,  const EST_Complex& a)
+friend std::ostream& operator<< (std::ostream& s,  const EST_Complex& a)
 { s << a.r << " " << a.i; return s;}
 };  
 

--- a/include/EST_Event.h
+++ b/include/EST_Event.h
@@ -90,7 +90,7 @@ public:
 	s << e.type << " " << e.rise_amp << " " << e.rise_dur
 	    << " " << e.fall_amp << " " << e.fall_dur
 	    << " " << e.start_amp << " " << e.start_pos
-            << endl;
+            << std::endl;
 	    return s;
 	}
 };
@@ -139,7 +139,7 @@ public:
 	    << " sf0:" << e.start_f0() << " spos:" << e.start_pos()
 	    << " pf0:" << e.peak_f0() << " ppos:" << e.peak_pos()
 	    << " ef0:" << e.end_f0() << " epos:" << e.end_pos()
-            << endl;
+            << std::endl;
 	    return s;
 	}
 };
@@ -176,7 +176,7 @@ public:
 	s << e.type << " " << e.amp() << " " << e.dur()
 	    << " " << e.tilt() << " " << e.pos()
 	    << " sf0 " << e.start_f0() << " " << e.start_pos()
-            << endl;
+            << std::endl;
 	    return s;
 	}
 

--- a/include/EST_Handleable.h
+++ b/include/EST_Handleable.h
@@ -37,7 +37,7 @@
 
 #include <climits>
 
-using namespace std;
+using namespace std; // FIXME: To be removed
 
 /** @class EST_Handleable
   * @ingroup supportclasses

--- a/include/EST_Ngrammar.h
+++ b/include/EST_Ngrammar.h
@@ -43,7 +43,7 @@
 #include <cstdarg>
 #include <cstdlib>
 
-using namespace std;
+using namespace std; // FIXME: To be removed
 
 #include "EST_String.h"
 #include "EST_Val.h"

--- a/include/EST_String.h
+++ b/include/EST_String.h
@@ -43,7 +43,7 @@ class EST_Regex;
 #include <cstring>
 #include <iostream>
 #include <climits>
-using namespace std;
+using namespace std;  // FIXME: To be removed
 #include "EST_Chunk.h"
 #include "EST_strcasecmp.h"
 #include "EST_bool.h"

--- a/include/EST_TDeque.h
+++ b/include/EST_TDeque.h
@@ -71,7 +71,7 @@ public:
   bool is_empty(void) const;
 
   /// print picture of state. Mostly useful for debugging.
-  ostream &print(ostream &s) const;
+  std::ostream &print(std::ostream &s) const;
 
   /**@name stack
     * 
@@ -111,7 +111,7 @@ public:
   T &shift() { return back_pop(); }
   ///@}
 
-  friend ostream& operator << (ostream &st, const EST_TDeque< T > &deq)
+  friend std::ostream& operator << (std::ostream &st, const EST_TDeque< T > &deq)
     {
         return deq.print(st);
     }

--- a/include/EST_THandle.h
+++ b/include/EST_THandle.h
@@ -37,7 +37,7 @@
 #include <iostream>
 #include "EST_bool.h"
 
-using namespace std;
+using namespace std; // FIXME: To be removed
 
 /** @class EST_THandle
   * @ingroup supportclasses
@@ -145,8 +145,8 @@ public:
   friend int operator != (const EST_THandle< BoxT, ObjectT > &a, const EST_THandle< BoxT, ObjectT > & b)
     { return !( a==b ); }
 
-  friend ostream & operator << (ostream &s, const EST_THandle< BoxT, ObjectT > &a)
-    { return s << "HANDLE"; }
+  friend std::ostream & operator << (std::ostream &s, const EST_THandle< BoxT, ObjectT > &a)
+    { (void)a; return s << "HANDLE"; }
 };
 
 #endif

--- a/include/EST_TKVL.h
+++ b/include/EST_TKVL.h
@@ -41,7 +41,7 @@
 
 #include <cmath>
 
-using namespace std;
+using namespace std; // FIXME: To be removed
 
 #include "EST_TList.h"
 #include "instantiate/EST_TKVLI.h"
@@ -63,7 +63,7 @@ template<class K, class V> class EST_TKVI {
 	return( (i.k == k) && (i.v == v) );
     }
 
-    friend  ostream& operator << (ostream& s, EST_TKVI<K,V> const &i)
+    friend  std::ostream& operator << (std::ostream& s, EST_TKVI<K,V> const &i)
         {  return s << i.k << "\t" << i.v << "\n"; }
 };
 
@@ -150,10 +150,10 @@ template<class K, class V> class EST_TKVL {
     /// apply function to each pair
     void map(void (*func)(K&, V&));
     
-    friend ostream& operator << (ostream& s, EST_TKVL<K,V> const &l)
+    friend std::ostream& operator << (std::ostream& s, EST_TKVL<K,V> const &l)
     {EST_Litem *p; 
         for (p = l.list.head(); p ; p = p->next()) 
-            s << l.list(p).k << "\t" << l.list(p).v << endl; 
+            s << l.list(p).k << "\t" << l.list(p).v << std::endl; 
         return s;
     } 
     

--- a/include/EST_TList.h
+++ b/include/EST_TList.h
@@ -234,7 +234,7 @@ template <class T> class EST_TList : public EST_UList
     EST_TList<T> &operator +=(const EST_TList<T> &a);
 
   /// print list
-    friend ostream& operator << (ostream &st, EST_TList<T> const &list) {
+    friend std::ostream& operator << (std::ostream &st, EST_TList<T> const &list) {
         EST_Litem *ptr; 
         for (ptr = list.head(); ptr != 0; ptr = ptr->next()) 
             st << list.item(ptr) << " "; 

--- a/include/EST_TMatrix.h
+++ b/include/EST_TMatrix.h
@@ -43,7 +43,7 @@
 
 #include <iostream>
 
-using namespace std;
+using namespace std; // FIXME: To be removed
 
 #include "EST_rw_status.h"
 #include "EST_TVector.h"

--- a/include/EST_TNamedEnum.h
+++ b/include/EST_TNamedEnum.h
@@ -53,7 +53,7 @@
 
 #include <cstring>
 
-using namespace std;
+using namespace std; // FIXME: To be removed
 
 #include "EST_String.h"
 #include "EST_rw_status.h"

--- a/include/EST_TTimeIndex.h
+++ b/include/EST_TTimeIndex.h
@@ -83,8 +83,8 @@ extern int operator !=(const EST_TTI_Entry<CONTAINER> &e1,
 		       const EST_TTI_Entry<CONTAINER> &e2);
 
 template<class CONTAINER>
-extern ostream& operator <<(
-			    ostream &s, 
+extern std::ostream& operator <<(
+			    std::ostream &s,
 			    const EST_TTI_Entry<CONTAINER> &e);
 #endif
 

--- a/include/EST_TVector.h
+++ b/include/EST_TVector.h
@@ -41,7 +41,7 @@
 #define __EST_TVector_H__
 
 #include <iostream>
-using namespace std;
+using namespace std; // FIXME: To be removed
 #include "EST_bool.h"
 #include "EST_rw_status.h"
 

--- a/include/EST_Token.h
+++ b/include/EST_Token.h
@@ -41,8 +41,9 @@
 #define __EST_TOKEN_H__
 
 #include <cstdio>
+#include <istream>
 
-using namespace std;
+using namespace std; // FIXME: To be removed
 
 #include "EST_String.h"
 #include "EST_common.h"
@@ -193,7 +194,7 @@ class EST_Token {
     const EST_String pos_description() const;
 
     ///
-    friend ostream& operator << (ostream& s, const EST_Token &p);
+    friend std::ostream& operator << (std::ostream& s, const EST_Token &p);
     
     ///
     EST_Token & operator = (const EST_Token &a);
@@ -246,7 +247,7 @@ class EST_TokenStream{
     EST_String PrePunctuationSymbols;
     EST_String Origin;
     FILE *fp;
-    istream *is;
+    std::istream *is;
     int fd;
     char *buffer;
     int buffer_length;
@@ -305,7 +306,7 @@ class EST_TokenStream{
     /// open a \ref EST_TokenStream for an already opened file
     int open(FILE *ofp, int close_when_finished);
     /// open a \ref EST_TokenStream for an already open istream
-    int open(istream &newis);
+    int open(std::istream &newis);
     /// open a \ref EST_TokenStream for string rather than a file
     int open_string(const EST_String &newbuffer);
     /// Close stream.
@@ -382,8 +383,8 @@ class EST_TokenStream{
     ///
     EST_TokenStream & operator >>(EST_String &p);
     ///
-    friend ostream& operator <<(ostream& s, EST_TokenStream &p);
-    //@}
+    friend std::ostream& operator <<(std::ostream& s, EST_TokenStream &p);
+    ///@}
 };
 
 /** Quote a string with given quotes and escape character

--- a/include/EST_Track.h
+++ b/include/EST_Track.h
@@ -681,7 +681,7 @@ public:
     EST_Track& operator = (const EST_Track& a);
     EST_Track& operator+=(const EST_Track &a); // add to existing track
     EST_Track& operator|=(const EST_Track &a); // add to existing track in parallel
-    friend ostream& operator << (ostream& s, const EST_Track &tr);
+    friend std::ostream& operator << (std::ostream& s, const EST_Track &tr);
 
     // Default constructor
     EST_Track(int num_frames, EST_TrackMap &map);

--- a/include/EST_TrackMap.h
+++ b/include/EST_TrackMap.h
@@ -35,7 +35,7 @@
 #define __EST_TRACKMAP_H__
 
 #include <climits>
-using namespace std;
+using namespace std; // FIXME: To be removed
 
 #include "EST_TNamedEnum.h"
 #include "EST_ChannelType.h"
@@ -156,7 +156,7 @@ public:
   const EST_TrackMap * object_ptr() const { return this; }
 
   friend class EST_Track;
-  friend ostream& operator << (ostream &st, const EST_TrackMap &m);
+  friend std::ostream& operator << (std::ostream &st, const EST_TrackMap &m);
 };
 
 /** Channel name maps map textual names for track channels to symbolic
@@ -174,5 +174,5 @@ extern EST_ChannelNameMap EST_default_channel_names;
 /// Definition of the names ESPS programs use for channels.
 extern EST_ChannelNameMap esps_channel_names;
 
-extern ostream& operator << (ostream &st, const EST_TrackMap &m);
+extern std::ostream& operator << (std::ostream &st, const EST_TrackMap &m);
 #endif

--- a/include/EST_UList.h
+++ b/include/EST_UList.h
@@ -43,7 +43,7 @@
 
 #include <iostream>
 
-using namespace std;
+using namespace std; // FIXME: To be removed
 
 #include "EST_common.h"
 #include "EST_String.h"

--- a/include/EST_WFST.h
+++ b/include/EST_WFST.h
@@ -47,7 +47,7 @@
 #include "EST_TVector.h"
 #include "EST_THash.h"
 #include "siod.h"
-#define wfst_error_msg(WMESS) (cerr << WMESS << endl,siod_error())
+#define wfst_error_msg(WMESS) (std::cerr << WMESS << std::endl,siod_error())
 
 #define WFST_ERROR_STATE -1
 

--- a/include/EST_Wagon.h
+++ b/include/EST_Wagon.h
@@ -55,7 +55,7 @@
 #include "omp.h"
 #endif
 
-#define wagon_error(WMESS) (cerr << WMESS << endl,exit(-1))
+#define wagon_error(WMESS) (std::cerr << WMESS << std::endl,exit(-1))
 
 // I get floating point exceptions of Alphas when I do any comparisons
 // with HUGE_VAL or FLT_MAX so I'll make my own

--- a/include/EST_iostream.h
+++ b/include/EST_iostream.h
@@ -48,10 +48,10 @@
 #if defined(__EMX__)
     /* For OS/2 */
 #   include <iostream>
-using namespace std;
+using namespace std; // FIXME: To be removed
 #elif defined(SYSTEM_IS_UNIX)
 #   include <iostream>
-using namespace std;
+using namespace std; // FIXME: To be removed
 #elif defined(SYSTEM_IS_WIN32)
 #   include "win32/EST_iostream_win32.h"
 #else

--- a/include/EST_lattice.h
+++ b/include/EST_lattice.h
@@ -249,7 +249,7 @@ operator + (const Lattice::symbol_t s1,
 {
     (void) s1;
     (void) s2;
-    cerr << "operator + makes no sense for Lattice::symbol_t !" << endl;
+    std::cerr << "operator + makes no sense for Lattice::symbol_t !" << std::endl;
     return Lattice::symbol_t();
 
 }

--- a/include/EST_math.h
+++ b/include/EST_math.h
@@ -57,7 +57,7 @@ extern "C" int isnan(double);
 #include <float.h>
 #endif
 
-using namespace std;
+using namespace std; // FIXME: To be removed
 
 #ifdef __cplusplus
 extern "C" {
@@ -88,7 +88,7 @@ extern "C" {
 #endif
 
 #ifndef isnanf
-#define isnanf isnan
+#define isnanf std::isnan
 #endif
 
 /* OS/2 with gcc EMX */

--- a/include/EST_model_types.h
+++ b/include/EST_model_types.h
@@ -66,11 +66,11 @@ struct stats_accumulator_FW
 typedef EST_TBox<stats_accumulator_FW> Boxed_stats_accumulator_FW;
 typedef EST_THandle<Boxed_stats_accumulator_FW,stats_accumulator_FW> refcounted_stats_accumulator_FW_P;
 
-ostream& operator <<(ostream &s, const refcounted_stats_accumulator_FW_P &);
+std::ostream& operator <<(std::ostream &s, const refcounted_stats_accumulator_FW_P &);
 
 typedef EST_TBox<stats_accumulator_HV> Boxed_stats_accumulator_HV;
 typedef EST_THandle<Boxed_stats_accumulator_HV,stats_accumulator_HV> refcounted_stats_accumulator_HV_P;
-ostream& operator <<(ostream &s, const refcounted_stats_accumulator_HV_P &);
+std::ostream& operator <<(std::ostream &s, const refcounted_stats_accumulator_HV_P &);
 
 /// an accumulator to be owned by every model
 /// - the underlying HV or FW accumulators are shared via
@@ -81,16 +81,16 @@ struct stats_accumulator
     refcounted_stats_accumulator_FW_P fw;
 };
 
-ostream& operator <<(ostream &s, const stats_accumulator_FW &);
-ostream& operator <<(ostream &s, const stats_accumulator_HV &);
+std::ostream& operator <<(std::ostream &s, const stats_accumulator_FW &);
+std::ostream& operator <<(std::ostream &s, const stats_accumulator_HV &);
 
 
 
 typedef EST_TBox<EST_DMatrix> Boxed_EST_DMatrix;
 typedef EST_THandle<Boxed_EST_DMatrix,EST_DMatrix> refcounted_EST_DMatrixP;
 
-ostream& operator <<(ostream &s, const Boxed_EST_DMatrix &);
-ostream& operator <<(ostream &s, const refcounted_EST_DMatrixP &);
+std::ostream& operator <<(std::ostream &s, const Boxed_EST_DMatrix &);
+std::ostream& operator <<(std::ostream &s, const refcounted_EST_DMatrixP &);
 
 //int operator ==(const Boxed_EST_DMatrix &a, 
 //		const Boxed_EST_DMatrix &b);
@@ -105,7 +105,7 @@ typedef EST_THandle<Boxed_EST_DVector,EST_DVector> refcounted_EST_DVectorP;
 int operator ==(const refcounted_EST_DVectorP &, 
 		const refcounted_EST_DVectorP &);
 
-ostream& operator <<(ostream &s, const refcounted_EST_DVectorP &);
+std::ostream& operator <<(std::ostream &s, const refcounted_EST_DVectorP &);
 
 
 

--- a/include/EST_simplestats.h
+++ b/include/EST_simplestats.h
@@ -201,7 +201,7 @@ enum EST_tprob_type {tprob_string, tprob_int, tprob_discrete};
           EST_String name;
           double prob;
           item_prob(i,name,prob);
-          cout << name << ": prob " << prob << endl;
+          std::cout << name << ": prob " << prob << std::endl;
        }
     \endverbatim
 

--- a/include/EST_strcasecmp.h
+++ b/include/EST_strcasecmp.h
@@ -44,7 +44,7 @@
 
 #ifdef __cplusplus
 #include <cstdlib>
-using namespace std;
+using namespace std; // FIXME: To be removed
 #else
 #include <stdlib.h>
 #endif

--- a/include/instantiate/EST_TListI.h
+++ b/include/instantiate/EST_TListI.h
@@ -47,7 +47,7 @@
 
 #include <iostream>
 
-using namespace std;
+using namespace std; // FIXME: Remove form header
 
 #include "instantiate/EST_TIteratorI.h"
 

--- a/include/win32/EST_iostream_win32.h
+++ b/include/win32/EST_iostream_win32.h
@@ -46,7 +46,7 @@
 /* This gets incuded from C */
 #ifdef __cplusplus
 #include <iostream>
-using namespace std;
+using namespace std; // FIXME: To be removed
 
 #undef read
 #undef write

--- a/include/win32/EST_unix_win32.h
+++ b/include/win32/EST_unix_win32.h
@@ -45,7 +45,7 @@
 /* force this to be loaded first */
 #ifdef __cplusplus
 #include <iostream>
-using namespace std;
+using namespace std; // FIXME: To be removed
 #endif
 
 #include<stdint.h>

--- a/intonation/tilt/tilt_analysis.cc
+++ b/intonation/tilt/tilt_analysis.cc
@@ -46,6 +46,8 @@
 #include "EST_Features.h"
 #include "EST_error.h"
 
+using namespace std;
+
 static int match_rf_point(EST_Track &fz, int b_start, int b_stop, 
 			  int e_start, int e_stop, 
 			  int &mi, int &mj);

--- a/ling_class/EST_Item_Content.cc
+++ b/ling_class/EST_Item_Content.cc
@@ -45,6 +45,8 @@
 #include "ling_class/EST_Item.h"
 #include "EST_error.h"
 
+using namespace std;
+
 void EST_Item_Content::copy(const EST_Item_Content &x)
 {
     f = x.f;

--- a/ling_class/EST_Relation.cc
+++ b/ling_class/EST_Relation.cc
@@ -44,6 +44,8 @@
 #include "ling_class/EST_Item.h"
 #include "relation_io.h"
 
+using namespace std;
+
 VAL_REGISTER_CLASS(relation,EST_Relation)
 
 EST_Relation::EST_Relation(const EST_String &name)

--- a/ling_class/EST_Utterance.cc
+++ b/ling_class/EST_Utterance.cc
@@ -46,6 +46,8 @@
 #include "EST_UtteranceFile.h"
 #include "EST_string_aux.h"
 
+using namespace std;
+
 const EST_String DEF_FILE_TYPE = "est_ascii";
 
 static void clear_up_sisilist(EST_TKVL<EST_Item_Content *,EST_Item *> &s);

--- a/ling_class/EST_UtteranceFile.cc
+++ b/ling_class/EST_UtteranceFile.cc
@@ -47,6 +47,8 @@
 #include "ling_class/EST_Utterance.h"
 #include "EST_UtteranceFile.h"
 
+using namespace std;
+
 static EST_read_status load_all_contents(EST_TokenStream &ts,
 //					 EST_THash<int,EST_Val> &sitems,
 					 EST_TVector < EST_Item_Content * > &sitems,

--- a/ling_class/EST_relation_aux.cc
+++ b/ling_class/EST_relation_aux.cc
@@ -49,6 +49,8 @@
 #include "EST_Token.h"
 
 static int is_in_class(const EST_String &name, EST_StrList &s);
+using namespace std;
+
 
 bool dp_match(const EST_Relation &lexical,
 	      const EST_Relation &surface,

--- a/ling_class/EST_relation_compare.cc
+++ b/ling_class/EST_relation_compare.cc
@@ -49,6 +49,7 @@
 #include "ling_class/EST_relation_compare.h"
 #include "EST_io_aux.h"
 
+using namespace std;
 
 int close_enough(EST_Item &a, EST_Item &b)
 {

--- a/ling_class/apml.cc
+++ b/ling_class/apml.cc
@@ -44,6 +44,8 @@
 #include "apml.h"
 #include "rxp/XML_Parser.h"
 
+using namespace std;
+
 static EST_Regex simpleIDRegex(".*#id(w\\([0-9]+\\))");
 static EST_Regex rangeIDRegex(".*#id(w\\([0-9]+\\)).*id(w\\([0-9]+\\))");
 static EST_Regex RXpunc("[\\.,\\?\\!\"]+");

--- a/ling_class/item_feats.cc
+++ b/ling_class/item_feats.cc
@@ -47,6 +47,8 @@
 #include "ling_class/EST_FeatureFunctionPackage.h"
 #include "EST_FeatureFunctionContext.h"
 
+using namespace std;
+
 const char *error_name(EST_Item_featfunc f)
 {
   (void)f;

--- a/ling_class/relation_io.cc
+++ b/ling_class/relation_io.cc
@@ -48,6 +48,8 @@
 #include "EST_Option.h"
 #include "relation_io.h"
 
+using namespace std;
+
 #define DEF_SAMPLE_RATE 16000
 #define HTK_UNITS_PER_SECOND 10000000
 

--- a/ling_class/standard_feature_functions.cc
+++ b/ling_class/standard_feature_functions.cc
@@ -45,6 +45,8 @@
 #include "ling_class/EST_Item_Content.h"
 #include "ling_class/EST_item_aux.h"
 
+using namespace std;
+
 EST_Val ff_duration(EST_Item *s)
 {
     if (iprev(s))

--- a/main/align_main.cc
+++ b/main/align_main.cc
@@ -46,6 +46,8 @@
 #include "EST.h"
 #include "EST_WFST.h"
 
+using namespace std;
+
 static int align_main(int argc, char **argv);
 static void nisttool_align(EST_Option &al);
 static void string_align(EST_Option &al);

--- a/main/bcat_main.cc
+++ b/main/bcat_main.cc
@@ -45,6 +45,8 @@
 #include "EST_String.h"
 #include "EST_error.h"
 
+using namespace std;
+
 #define BUFFER_SIZE (1024)
 
 

--- a/main/ch_lab_main.cc
+++ b/main/ch_lab_main.cc
@@ -44,6 +44,7 @@
 #include "EST_string_aux.h"
 
 int check_vocab(EST_Relation &a, EST_StrList &vocab);
+using namespace std;
 
 /** @name <command>ch_lab</command> <emphasis>Label file manipulation</emphasis>
     @id ch_lab_manual

--- a/main/ch_track_main.cc
+++ b/main/ch_track_main.cc
@@ -40,6 +40,8 @@
 #include "EST.h"
 #include "EST_cmd_line_options.h"
 
+using namespace std;
+
 #define DEFAULT_TIME_SCALE 0.001
 
 int StrListtoIList(EST_StrList &s, EST_IList &il);

--- a/main/ch_utt_main.cc
+++ b/main/ch_utt_main.cc
@@ -43,6 +43,8 @@
 #include "EST_ling_class.h"
 #include "EST_cmd_line.h"
 
+using namespace std;
+
 int main(int argc, char *argv[])
 {
     EST_String out_file, ext;

--- a/main/ch_wave_main.cc
+++ b/main/ch_wave_main.cc
@@ -46,6 +46,7 @@
 #include "EST_wave_aux.h"
 #include "EST.h"
 
+using namespace std;
 #define sgn(x) (x>0?1:x?-1:0)
 
 void wave_extract_channel(EST_Wave &single, const EST_Wave &multi,  EST_IList &ch_list);

--- a/main/design_filter_main.cc
+++ b/main/design_filter_main.cc
@@ -77,6 +77,7 @@ program.
 //@options
 
 //@}
+using namespace std;
 
 int main (int argc, char *argv[])
 {

--- a/main/dp_main.cc
+++ b/main/dp_main.cc
@@ -42,6 +42,8 @@
 #include <cmath>
 #include "EST.h"
 
+using namespace std;
+
 EST_read_status load_TList_of_StrVector(EST_TList<EST_StrVector> &w,
 					const EST_String &filename,
 					const int vec_len);

--- a/main/na_play_main.cc
+++ b/main/na_play_main.cc
@@ -120,6 +120,7 @@ sunaudio is the default.
 
 //@}
 
+using namespace std;
 
 int main (int argc, char *argv[])
 {

--- a/main/na_record_main.cc
+++ b/main/na_record_main.cc
@@ -82,6 +82,7 @@ currently doesn't support NAS audio in.
 
 //@}
 
+using namespace std;
 
 int main (int argc, char *argv[])
 {

--- a/main/ngram_build_main.cc
+++ b/main/ngram_build_main.cc
@@ -42,6 +42,7 @@
 #include "EST_Ngrammar.h"
 #include "EST_Pathname.h"
 
+using namespace std;
 
 
 /** @name <command>ngram_build</command> <emphasis>Train n-gram language model</emphasis>

--- a/main/ngram_test_main.cc
+++ b/main/ngram_test_main.cc
@@ -39,6 +39,7 @@
 #include "EST.h"
 #include "EST_Ngrammar.h"
 
+using namespace std;
 
 /** @name <command>ngram_test</command> <emphasis> Test n-gram language model </emphasis>
     @id ngram_test_manual

--- a/main/ols_main.cc
+++ b/main/ols_main.cc
@@ -44,6 +44,8 @@
 #include "EST_multistats.h"
 #include "EST_cmd_line.h"
 
+using namespace std;
+
 static void load_ols_data(EST_FMatrix &X, EST_FMatrix &Y, WDataSet &d);
 static int ols_main(int argc, char **argv);
 

--- a/main/ols_test_main.cc
+++ b/main/ols_test_main.cc
@@ -46,6 +46,8 @@
 #include "EST_Token.h"
 #include "EST_cmd_line.h"
 
+using namespace std;
+
 static int ols_test_main(int argc, char **argv);
 static void load_ols_data(EST_FMatrix &X, EST_FMatrix &Y, WDataSet &d);
 

--- a/main/pda_main.cc
+++ b/main/pda_main.cc
@@ -41,6 +41,8 @@
 #include "sigpr/EST_sigpr_utt.h"
 #include "EST_cmd_line_options.h"
 
+using namespace std;
+
 void set_parameters(EST_Features &a_list, EST_Option &al);
 
 void option_override(EST_Features &op, EST_Option al, 

--- a/main/pitchmark_main.cc
+++ b/main/pitchmark_main.cc
@@ -45,6 +45,7 @@
 #include "EST_speech_class.h"
 #include "sigpr/EST_pitchmark.h"
 
+using namespace std;
 
 void set_options(EST_Features &op, EST_Option &al);
 

--- a/main/scfg_make_main.cc
+++ b/main/scfg_make_main.cc
@@ -48,6 +48,8 @@
 #include "EST_SCFG.h"
 #include "siod.h"
 
+using namespace std;
+
 EST_String outfile = "-";
 EST_String domain = "nlogp";
 EST_String values = "equal";

--- a/main/scfg_parse_main.cc
+++ b/main/scfg_parse_main.cc
@@ -47,6 +47,8 @@
 #include "EST_SCFG_Chart.h"
 #include "siod.h"
 
+using namespace std;
+
 static EST_String outfile = "-";
 
 static int scfg_parse_main(int argc, char **argv);

--- a/main/scfg_test_main.cc
+++ b/main/scfg_test_main.cc
@@ -48,6 +48,8 @@
 #include "EST_SCFG.h"
 #include "siod.h"
 
+using namespace std;
+
 static EST_String outfile = "-";
 
 static int scfg_test_main(int argc, char **argv);

--- a/main/scfg_train_main.cc
+++ b/main/scfg_train_main.cc
@@ -49,6 +49,8 @@
 #include "EST_SCFG.h"
 #include "siod.h"
 
+using namespace std;
+
 static EST_String outfile = "-";
 
 

--- a/main/sig2fv_main.cc
+++ b/main/sig2fv_main.cc
@@ -45,6 +45,8 @@
 #include "sigpr/EST_sigpr_utt.h"
 #include "sigpr/EST_filter.h"
 
+using namespace std;
+
 #define EPSILON (0.0001)
 
 #define DEFAULT_FRAME_SIZE 0.01

--- a/main/sigfilter_main.cc
+++ b/main/sigfilter_main.cc
@@ -46,6 +46,8 @@
 #include "EST_sigpr.h"
 #include "EST_wave_aux.h"
 
+using namespace std;
+
 void inv_filter_ola(EST_Wave &sig, EST_Track &lpc, EST_Wave &res);
 void frame_filter(EST_Wave &sig, EST_Track &lpc, EST_Wave &res);
 void inv_lpc_filter_ola(EST_Wave &in_sig, EST_Track &lpc, EST_Wave &out_sig);

--- a/main/siod_main.cc
+++ b/main/siod_main.cc
@@ -43,6 +43,8 @@
 #include "EST_Pathname.h"
 #include "siod.h"
 
+using namespace std;
+
 static void siod_lisp_vars(void);
 static void siod_load_default_files(void);
 

--- a/main/spectgen_main.cc
+++ b/main/spectgen_main.cc
@@ -41,6 +41,8 @@
 #include "EST_cmd_line_options.h"
 #include "sigpr/EST_spectrogram.h"
 
+using namespace std;
+
 #define DEFAULT_FRAME_SIZE 0.001
 #define DEFAULT_FRAME_LENGTH 0.008
 #define DEFAULT_ORDER 256

--- a/main/tilt_analysis_main.cc
+++ b/main/tilt_analysis_main.cc
@@ -44,6 +44,9 @@
 #include "ling_class/EST_relation_aux.h"
 #include "EST_string_aux.h"
 
+using namespace std;
+
+
 #define SIL_NAMES "sil !ENTER !EXIT"
 #define EVENT_NAMES "a rb arb m mrb"
 

--- a/main/tilt_synthesis_main.cc
+++ b/main/tilt_synthesis_main.cc
@@ -49,6 +49,7 @@
  */
 
 //@{
+using namespace std;
 
 void extract_channels(EST_Wave &single, const EST_Wave &multi,  EST_IList &ch_list);
 

--- a/main/viterbi_main.cc
+++ b/main/viterbi_main.cc
@@ -42,6 +42,8 @@
 #include <cmath>
 #include "EST.h"
 
+using namespace std;
+
 EST_read_status load_TList_of_StrVector(EST_TList<EST_StrVector> &w,
 					const EST_String &filename,
 					const int vec_len);

--- a/main/wagon_main.cc
+++ b/main/wagon_main.cc
@@ -49,6 +49,8 @@
 #include "EST_Wagon.h"
 #include "EST_cmd_line.h"
 
+using namespace std;
+
 enum wn_strategy_type {wn_decision_list, wn_decision_tree};
 
 static wn_strategy_type wagon_type = wn_decision_tree;

--- a/main/wagon_test_main.cc
+++ b/main/wagon_test_main.cc
@@ -47,6 +47,8 @@
 #include "EST_Token.h"
 #include "EST_cmd_line.h"
 
+using namespace std;
+
 static int wagon_test_main(int argc, char **argv);
 static LISP find_feature_value(const char *feature, 
 			       LISP vector, LISP description);

--- a/main/wfst_build_main.cc
+++ b/main/wfst_build_main.cc
@@ -72,6 +72,7 @@ static int wfst_build_main(int argc, char **argv);
 /**@name Synopsis
   */
 //@{
+using namespace std;
 
 //@synopsis
 

--- a/main/wfst_run_main.cc
+++ b/main/wfst_run_main.cc
@@ -60,6 +60,7 @@ static int wfst_run_main(int argc, char **argv);
 //@{
 
 //@synopsis
+using namespace std;
 
 /**
 This program runs a WFST on some given data.  It works in either

--- a/main/wfst_train_main.cc
+++ b/main/wfst_train_main.cc
@@ -45,6 +45,8 @@
 #include "EST_simplestats.h"
 #include "EST_WFST.h"
 
+using namespace std;
+
 LISP load_string_data(EST_WFST &wfst,EST_String &filename);
 void wfst_train(EST_WFST &wfst, LISP data);
 

--- a/main/xml_parser_main.cc
+++ b/main/xml_parser_main.cc
@@ -47,6 +47,8 @@
 #include "EST_cmd_line_options.h"
 #include "rxp/XML_Parser.h"
 
+using namespace std;
+
 struct Parse_State
   {
   int depth;

--- a/sigpr/EST_Window.cc
+++ b/sigpr/EST_Window.cc
@@ -45,6 +45,8 @@
 #include "EST_TNamedEnum.h"
 #include "EST_math.h"
 
+using namespace std;
+
 //static inline int irint(float f) { return (int)(f+0.5); }
 //static inline int irint(double f) { return (int)(f+0.5); }
 static inline int min(int a, int b) { return (a<b)?a:b; }

--- a/sigpr/delta.cc
+++ b/sigpr/delta.cc
@@ -40,6 +40,9 @@
 #include <cstdlib>
 #include "EST_Track.h"
 #include "EST_Wave.h"
+
+using namespace std;
+
 # define MAX_DELTA_ORDER 2
 /// max. number of points on which the delta co-eff is based
 # define MAX_REGRESSION_LENGTH 4

--- a/sigpr/filter.cc
+++ b/sigpr/filter.cc
@@ -45,6 +45,8 @@
 #include "sigpr/EST_Window.h"
 #include "EST_error.h"
 
+using namespace std;
+
 // there are multiple possible styles of this because of different
 // possibilities of where to change the filter coefficients.
 

--- a/sigpr/pda/srpd1.3.cc
+++ b/sigpr/pda/srpd1.3.cc
@@ -72,6 +72,8 @@
 #include "srpd.h"
 #include "EST_cutils.h"
 #include "EST_Wave.h"
+using namespace std;
+
 
 #ifndef MAXSHORT
 #define MAXSHORT 32767

--- a/sigpr/pitchmark.cc
+++ b/sigpr/pitchmark.cc
@@ -50,6 +50,7 @@ written in matlab.
 #include "EST_wave_aux.h"
 #include "EST_track_aux.h"
 
+using namespace std;
 
 void delta(EST_Wave &tr, EST_Wave &d, int regression_length);
 

--- a/sigpr/sigpr_frame.cc
+++ b/sigpr/sigpr_frame.cc
@@ -44,6 +44,8 @@
 #include "EST_error.h"
 #include "EST_TBuffer.h"
 
+using namespace std;
+
 #define ALMOST1 0.99999
 #define MAX_ABS_CEPS 4.0
 

--- a/sigpr/sigpr_utt.cc
+++ b/sigpr/sigpr_utt.cc
@@ -49,6 +49,8 @@
 #include "EST_types.h"
 #include "EST_string_aux.h"
 
+using namespace std;
+
 void sigpr_acc(EST_Wave &sig, EST_Track &fv, EST_Features &op, 
 		const EST_StrList &slist);
 

--- a/sigpr/spectrogram.cc
+++ b/sigpr/spectrogram.cc
@@ -48,6 +48,7 @@
 #include "sigpr/EST_spectrogram.h"
 #include "sigpr/EST_misc_sigpr.h"
 
+using namespace std;
 
 void make_spectrogram(EST_Wave &sig, EST_Track &sp, EST_Features &op)
 {

--- a/siod/io.cc
+++ b/siod/io.cc
@@ -53,6 +53,8 @@
 #include "siodp.h"
 #include "io.h"
 
+using std::cout;
+
 EST_Regex RxURL("\\([a-z]+\\)://?\\([^/:]+\\)\\(:\\([0-9]+\\)\\)?\\(.*\\)");
 EST_Regex RxFILEURL("file:.*");
 static EST_Regex ipnum("[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+");

--- a/siod/siod.cc
+++ b/siod/siod.cc
@@ -51,6 +51,8 @@ template <> EST_Regex *EST_THash<EST_String, EST_Regex *>::Dummy_Value = NULL;
   Instantiate_TStringHash_T(EST_Regex *, hash_string_regex)
 #endif
 
+using namespace std;
+
 static EST_TStringHash<EST_Regex *> regexes(100);
 
 int siod_init(int heap_size)

--- a/siod/siod_est.cc
+++ b/siod/siod_est.cc
@@ -61,6 +61,8 @@ Instantiate_TStringHash(LISP)
 
 #endif
 
+using namespace std;
+
 // To make garbage collection easy the following functions offer an index
 // of arbitrary objects to LISP cells.  You can use this to return the
 // same LISP cell for the same object.  This is used for utterance

--- a/siod/slib.cc
+++ b/siod/slib.cc
@@ -93,6 +93,8 @@ Cambridge, MA 02138
 #include "winsock2.h"
 #endif
 
+using namespace std;
+
 static int restricted_function_call(LISP l);
 static long repl(struct repl_hooks *h);
 static void gc_mark_and_sweep(void);

--- a/siod/slib_doc.cc
+++ b/siod/slib_doc.cc
@@ -14,6 +14,9 @@
 #include "siodp.h"
 #include "siodeditline.h"
 
+using std::cerr;
+using std::endl;
+
 void setdoc(LISP name,LISP doc)
 {
     /* Set documentation string for name */

--- a/siod/slib_format.cc
+++ b/siod/slib_format.cc
@@ -47,6 +47,8 @@
 #include "siod.h"
 #include "siodp.h"
 
+using namespace std;
+
 static int format_string(LISP fd,const char *formatstr, const char *str);
 static int format_lisp(LISP fd,const char *formatstr, LISP a);
 static int format_int(LISP fd,const char *formatstr, int i);

--- a/siod/slib_repl.cc
+++ b/siod/slib_repl.cc
@@ -39,6 +39,8 @@ Cambridge, MA 02138
 #include "siodp.h"
 #include "siodeditline.h"
 
+using namespace std;
+
 int siod_repl(int interactive)
 {
     int retval;

--- a/siod/slib_server.cc
+++ b/siod/slib_server.cc
@@ -13,6 +13,8 @@
 #include "siod.h"
 #include "siodp.h"
 
+using namespace std;
+
 int siod_server_socket = -1;
 
 LISP siod_send_lisp_to_client(LISP x)

--- a/siod/slib_xtr.cc
+++ b/siod/slib_xtr.cc
@@ -18,6 +18,8 @@ Array-hacking code moved to another source file.
 #include "siod.h"
 #include "siodp.h"
 
+using namespace std;
+
 static LISP bashnum = NIL;
 
 static LISP array_gc_relocate(LISP ptr)

--- a/speech_class/EST_Track.cc
+++ b/speech_class/EST_Track.cc
@@ -47,6 +47,8 @@
 #include "EST_TrackFile.h"
 #include "EST_error.h"
 
+using namespace std;
+
 const int EST_Track::default_sample_rate=16000; // occasionally needed for xmg files
 const float EST_Track::default_frame_shift=0.005; // default frame spacing.
 

--- a/speech_class/EST_TrackFile.cc
+++ b/speech_class/EST_TrackFile.cc
@@ -56,6 +56,8 @@
 #include "EST_WaveFile.h"
 #include "EST_wave_utils.h"
 
+using namespace std;
+
 // size of locally allocated buffer. If more channels than this we have to
 // call new
 

--- a/speech_class/EST_TrackFile.h
+++ b/speech_class/EST_TrackFile.h
@@ -42,6 +42,7 @@
 #define __EST_TRACKFILE_H__
 
 #include "EST_Token.h"
+#include "EST_Track.h"
 #include "EST_TNamedEnum.h"
 #include "EST_String.h"
 #include "EST_rw_status.h"

--- a/speech_class/EST_Wave.cc
+++ b/speech_class/EST_Wave.cc
@@ -53,6 +53,7 @@
 
 #include "waveP.h"
 
+using namespace std;
 #define sgn(x) (x>0?1:x?-1:0)
 
 const EST_String DEF_FILE_TYPE = "riff";

--- a/speech_class/EST_WaveFile.cc
+++ b/speech_class/EST_WaveFile.cc
@@ -46,6 +46,8 @@
 #include <cstdio>
 #include <cmath>
 
+using namespace std;
+
 void extract(EST_Wave &sig, EST_Option &al);
 
 typedef 

--- a/speech_class/EST_track_aux.cc
+++ b/speech_class/EST_track_aux.cc
@@ -48,6 +48,8 @@
 #include "EST_track_aux.h"
 #include "EST_error.h"
 
+using namespace std;
+
 //static inline int irint(float f) { return (int)(f+0.5); }
 //static inline int irint(double f) { return (int)(f+0.5); }
 //static inline int ifloor(float f) { return (int)(f); }

--- a/speech_class/EST_wave_aux.cc
+++ b/speech_class/EST_wave_aux.cc
@@ -48,6 +48,8 @@
 #include "EST_io_aux.h"
 #include "EST_error.h"
 
+using namespace std;
+
 void extract(EST_Wave &sig, EST_Option &al);
 
 /* Allow EST_Wave to be used in an EST_Val */

--- a/speech_class/EST_wave_cuts.cc
+++ b/speech_class/EST_wave_cuts.cc
@@ -48,6 +48,8 @@
 #include "ling_class/EST_Relation.h"
 #include "ling_class/EST_item_aux.h"
 
+using namespace std;
+
 static int wave_subwave(EST_Wave &subsig,EST_Wave &sig, 
 			float offset, float length);
 

--- a/speech_class/EST_wave_io.cc
+++ b/speech_class/EST_wave_io.cc
@@ -50,6 +50,8 @@
 #include "waveP.h"
 #include "EST_FileType.h"
 
+using namespace std;
+
 static int def_load_sample_rate = 16000;
 
 /*************************************************************************/

--- a/speech_class/EST_wave_temp.cc
+++ b/speech_class/EST_wave_temp.cc
@@ -47,6 +47,8 @@
 #include "EST_simplestats.h"
 #include "EST_cutils.h"
 
+using namespace std;
+
 EST_Wave difference(EST_Wave &a, EST_Wave &b)
 {
     int i, j;

--- a/speech_class/esps_utils.cc
+++ b/speech_class/esps_utils.cc
@@ -64,6 +64,8 @@
 #include "EST_wave_utils.h"
 #include "esps_utils.h"
 
+using namespace std;
+
 /* First you must realise there is in fact a number of very similar but */
 /* subtly different header formats that appear on ESPS files.           */
 /* ESPS_FEA and ESPS_SD (others for filters, spectrograms, etc)         */

--- a/speech_class/esps_utils.h
+++ b/speech_class/esps_utils.h
@@ -39,6 +39,8 @@
 #ifndef __ESPS_IO_H__
 #define __ESPS_IO_H__
 
+#include <cstdio>
+#include "EST_TrackFile.h"
 #define ESPS_MAGIC 27162
 struct ESPS_PREAMBLE {
     int machine_code;   /* the machine that generated this (4 is sun) */

--- a/speech_class/ssff.cc
+++ b/speech_class/ssff.cc
@@ -55,6 +55,8 @@
 #include "EST_TrackFile.h"
 #include "EST_FileType.h"
 
+using namespace std;
+
 EST_read_status EST_TrackFile::load_ssff(const EST_String filename, 
 					EST_Track &tr, float ishift, float startt)
 {

--- a/stats/EST_DProbDist.cc
+++ b/stats/EST_DProbDist.cc
@@ -46,6 +46,8 @@
 #include "EST_TKVL.h"
 #include "EST_simplestats.h"
 
+using namespace std;
+
 /* We share ints and pointers for two types of probability distributions */
 /* The know discrete sets can be indexed by ints which is *much* faster  */
 /* the indices pass around a pointers but the lower part contain ints in */

--- a/stats/EST_Discrete.cc
+++ b/stats/EST_Discrete.cc
@@ -45,6 +45,8 @@
 #include "EST_String.h"
 #include "EST_simplestats.h"
 
+using namespace std;
+
 static void Discrete_val_delete_funct(void *d) { delete (int *)d; }
 
 EST_Discrete::~EST_Discrete() 

--- a/stats/EST_cluster.cc
+++ b/stats/EST_cluster.cc
@@ -45,6 +45,8 @@
 #include "EST_string_aux.h"
 #include <cfloat>
 
+using namespace std;
+
 int fn_cluster(EST_FMatrix &m, EST_CBK &cbk, float d);
 int nn_cluster(EST_FMatrix &m, EST_CBK &cbk, float d);
 int nn_cluster2(EST_FMatrix &m, EST_CBK &cbk, float d);

--- a/stats/EST_multistats.cc
+++ b/stats/EST_multistats.cc
@@ -39,6 +39,8 @@
 #include <cmath>
 #include "EST_multistats.h"
 
+using namespace std;
+
 float mean(EST_FVector &v)
 {
   int i;

--- a/stats/EST_ols.cc
+++ b/stats/EST_ols.cc
@@ -40,6 +40,8 @@
 #include "EST_multistats.h"
 #include "EST_simplestats.h"
 
+using namespace std;
+
 static void ols_load_selected_feats(const EST_FMatrix &X, 
 				    const EST_IVector &included,
 				    EST_FMatrix &Xl);

--- a/stats/EST_viterbi.cc
+++ b/stats/EST_viterbi.cc
@@ -42,6 +42,8 @@
 #include <cstdio>
 #include "EST_viterbi.h"
 
+using namespace std;
+
 static void init_paths_array(EST_VTPoint *n,int num_states);
 static void debug_output_1(EST_VTPoint *p,EST_VTCandidate *c, 
 			   EST_VTPath *np, int i);

--- a/stats/confusion.cc
+++ b/stats/confusion.cc
@@ -41,6 +41,8 @@
 #include "EST_math.h"
 #include "EST_types.h"
 
+using namespace std;
+
 int nth(EST_String name, EST_TList<EST_String> &lex)
 {
     EST_Litem *p;

--- a/stats/dynamic_program.cc
+++ b/stats/dynamic_program.cc
@@ -41,6 +41,8 @@
 #include "EST_math.h"
 #include "ling_class/EST_Utterance.h"
 
+using namespace std;
+
 typedef EST_TVector<EST_Item*> EST_Item_ptr_Vector;
 static EST_Item *const def_val_item_ptr = NULL;
 template <> EST_Item* const *EST_Item_ptr_Vector::def_val = &def_val_item_ptr;

--- a/stats/kalman_filter/EST_kalman.cc
+++ b/stats/kalman_filter/EST_kalman.cc
@@ -43,6 +43,8 @@
 #include "EST.h"
 #include "EST_kalman.h"
 
+using namespace std;
+
 static bool kalman_filter_param_check(EST_FVector &x,
 				      EST_FMatrix &P,
 				      EST_FMatrix &Q,

--- a/stats/wagon/dlist.cc
+++ b/stats/wagon/dlist.cc
@@ -51,6 +51,8 @@
 #include "EST_FMatrix.h"
 #include "EST_multistats.h"
 
+using namespace std;
+
 static WDlist *wagon_decision_list();
 static void do_dlist_summary(WDlist *dlist, WDataSet &dataset);
 static WDlist *dlist_score_question(WQuestion &q, WVectorList &ds);

--- a/stats/wagon/wagon.cc
+++ b/stats/wagon/wagon.cc
@@ -52,6 +52,8 @@
 #include "EST_Wagon.h"
 #include "EST_math.h"
 
+using namespace std;
+
 Discretes wgn_discretes;
 
 WDataSet wgn_dataset;

--- a/stats/wagon/wagon_aux.cc
+++ b/stats/wagon/wagon_aux.cc
@@ -46,6 +46,7 @@
 #include "EST_Wagon.h"
 #include "EST_math.h"
 
+using namespace std;
 
 EST_Val WNode::predict(const WVector &d)
 {

--- a/stats/wagon/wagonint.cc
+++ b/stats/wagon/wagonint.cc
@@ -44,6 +44,8 @@
 #include "EST_Token.h"
 #include "EST_Wagon.h"
 
+using namespace std;
+
 int wagon_ask_question(LISP question, LISP value)
 {
     const char *str_oper = wgn_ques_oper_str(question);

--- a/testsuite/complex_example.cc
+++ b/testsuite/complex_example.cc
@@ -38,6 +38,8 @@
 #include <iostream>
 #include <cstdio>
 
+using namespace std;
+
 int main()
 {
     EST_Complex z1(4.0, 3.0);

--- a/testsuite/complex_regression.cc
+++ b/testsuite/complex_regression.cc
@@ -38,6 +38,8 @@
 #include <iostream>
 #include <cstdio>
 
+using namespace std;
+
 int main()
 {
     EST_Complex z(4.0, 3.0);

--- a/testsuite/deq_example.cc
+++ b/testsuite/deq_example.cc
@@ -41,6 +41,8 @@
 #include "EST_TDeque.h"
 #include "EST_String.h"
 
+using namespace std;
+
 
 /**@name EST_TDeque:example
   * 

--- a/testsuite/feature_example.cc
+++ b/testsuite/feature_example.cc
@@ -34,6 +34,8 @@
 #include "EST_unix.h"
 #include "EST_ling_class.h"
 
+using namespace std;
+
 
 /** @name Feature and Val Classes Example Code
   */

--- a/testsuite/feature_regression.cc
+++ b/testsuite/feature_regression.cc
@@ -34,6 +34,8 @@
 #include "EST_unix.h"
 #include "EST_ling_class.h"
 
+using namespace std;
+
 
 /** @name Feature and Val Classes Example Code
   */

--- a/testsuite/handle_example.cc
+++ b/testsuite/handle_example.cc
@@ -48,6 +48,9 @@
 #include "EST_TBox.h"
 #include "EST_String.h"
 
+using namespace std;
+
+
 /**@name EST_THandle:example
   * 
   * Example of using the THandle reference counted pointer type.

--- a/testsuite/handle_regression.cc
+++ b/testsuite/handle_regression.cc
@@ -45,6 +45,8 @@
 #include "EST_THandle.h"
 #include "EST_String.h"
 
+using namespace std;
+
 
 int main(void)
 {

--- a/testsuite/hash_example.cc
+++ b/testsuite/hash_example.cc
@@ -44,6 +44,8 @@
 #include "EST_THash.h"
 #include "EST_String.h"
 
+using namespace std;
+
 // a very boring thing to do to a pair, see map below
 
 static void look_at(EST_String &s, int &l)

--- a/testsuite/hash_regression.cc
+++ b/testsuite/hash_regression.cc
@@ -45,6 +45,8 @@
 #include "EST_Token.h"
 #include "EST_THash.h"
 
+using namespace std;
+
 #define LINE_LENGTH 1000
 
 EST_Regex RX_Word("[A-Z]?[a-z]+\\('[a-z]+\\)?");

--- a/testsuite/kvl_example.cc
+++ b/testsuite/kvl_example.cc
@@ -43,6 +43,9 @@
 #include "EST_util_class.h"
 #include "EST_types.h"
 
+using namespace std;
+
+
 #if defined(DATAC)
 #    define __STRINGIZE(X) #X
 #    define DATA __STRINGIZE(DATAC)

--- a/testsuite/kvl_regression.cc
+++ b/testsuite/kvl_regression.cc
@@ -43,6 +43,9 @@
 #include "EST_util_class.h"
 #include "EST_types.h"
 
+using namespace std;
+
+
 /**@name key_value_example
   * 
   * some stuff about lists

--- a/testsuite/ling_regression.cc
+++ b/testsuite/ling_regression.cc
@@ -58,7 +58,7 @@ int main(void)
 
 	EST_String name = getString(*i, "name", EST_String::Empty, status);
 
-	cout << "Name=" << name << "\n";
+	std::cout << "Name=" << name << std::endl;
     }
   
     exit(0);

--- a/testsuite/list_regression.cc
+++ b/testsuite/list_regression.cc
@@ -41,6 +41,8 @@
 #include "EST_TList.h"
 #include "EST_String.h"
 
+using namespace std;
+
 Declare_TList(EST_String)
 
 int

--- a/testsuite/named_enum_example.cc
+++ b/testsuite/named_enum_example.cc
@@ -42,6 +42,8 @@
 #include <iostream>
 #include "EST_TNamedEnum.h"
 
+using namespace std;
+
 #if defined(DATAC)
 #    define __STRINGIZE(X) #X
 #    define DATA __STRINGIZE(DATAC)

--- a/testsuite/named_enum_regression.cc
+++ b/testsuite/named_enum_regression.cc
@@ -42,6 +42,8 @@
 #include "EST_TNamedEnum.h"
 #include "EST_String.h"
 
+using namespace std;
+
 #    define InfoType const char *
 
 typedef enum { c_red=1, c_blue=2, c_green=3, c_unknown=666} Colour;

--- a/testsuite/pathname_example.cc
+++ b/testsuite/pathname_example.cc
@@ -41,6 +41,8 @@
 #include <cstdlib>
 #include "EST_Pathname.h"
 
+using namespace std;
+
 #if defined(DATAC)
 #    define __STRINGIZE(X) #X
 #    define DATA __STRINGIZE(DATAC)

--- a/testsuite/pathname_regression.cc
+++ b/testsuite/pathname_regression.cc
@@ -41,6 +41,8 @@
 #include <cstdlib>
 #include "EST_Pathname.h"
 
+using namespace std;
+
 int main(void)
 {
 

--- a/testsuite/sigpr_regression.cc
+++ b/testsuite/sigpr_regression.cc
@@ -40,6 +40,8 @@
 
 #include "EST_sigpr.h"
 
+using namespace std;
+
 /**@name sig2fv:example
   * 
   * Some examples of track manipulations.

--- a/testsuite/string_example.cc
+++ b/testsuite/string_example.cc
@@ -37,6 +37,8 @@
 #include <iostream>
 #include <cstdio>
 
+using namespace std;
+
 int main()
 {
     EST_String example("hello world");

--- a/testsuite/string_regression.cc
+++ b/testsuite/string_regression.cc
@@ -36,6 +36,8 @@
 #include "EST_String.h"
 #include <iostream>
 
+using namespace std;
+
 int main()
 
 {

--- a/testsuite/token_example.cc
+++ b/testsuite/token_example.cc
@@ -41,6 +41,8 @@
 #include <cstdlib>
 #include "EST_Token.h"
 
+using namespace std;
+
 #if defined(DATAC)
 #    define __STRINGIZE(X) #X
 #    define DATA __STRINGIZE(DATAC)

--- a/testsuite/token_regression.cc
+++ b/testsuite/token_regression.cc
@@ -41,6 +41,8 @@
 #include <cstdlib>
 #include "EST_Token.h"
 
+using namespace std;
+
 static void binary_read_test();
 
 static void find_tokens(EST_TokenStream &ts)

--- a/testsuite/track_regression.cc
+++ b/testsuite/track_regression.cc
@@ -44,6 +44,8 @@
 #include "EST_TrackMap.h"
 #include "EST_Track.h"
 
+using namespace std;
+
 void dump_track(EST_Track &tr, EST_String comment)
 {
   printf("[ Track %s\n", (const char *)comment);

--- a/testsuite/xml_example.cc
+++ b/testsuite/xml_example.cc
@@ -42,6 +42,8 @@
 #include <iostream>
 #include "rxp/XML_Parser.h"
 
+using namespace std;
+
 #if defined(DATAC)
 #    define __STRINGIZE(X) #X
 #    define DATA __STRINGIZE(DATAC)

--- a/utils/cmd_line.cc
+++ b/utils/cmd_line.cc
@@ -50,6 +50,8 @@
 #include "EST_Pathname.h"
 #include "EST_Features.h"
 
+using namespace std;
+
 // This is reset by the command line options functions to argv[0]
 EST_String est_progname = "ESTtools";
 

--- a/utils/est_file.cc
+++ b/utils/est_file.cc
@@ -43,6 +43,8 @@
 #include "EST_Option.h"
 #include "EST_Features.h"
 
+using namespace std;
+
 static EST_TValuedEnumDefinition<EST_EstFileType, const char *, NO_INFO> 
 estfile_names[] =
 {

--- a/utils/filetrans.cc
+++ b/utils/filetrans.cc
@@ -43,6 +43,8 @@
 #include "EST_String.h"
 #include "EST_io_aux.h"
 
+using namespace std;
+
 // The following key is used when stuffing files down a socket.
 // This key in when received denotes the end of file.  Any occurrence
 // of key in the file with have X inserted in it, and the receiving end

--- a/utils/util_io.cc
+++ b/utils/util_io.cc
@@ -51,6 +51,8 @@
 #include "EST_cutils.h"
 #include "EST_Token.h"
 
+using namespace std;
+
 EST_String make_tmp_filename()
 {
     // returns tmp filename


### PR DESCRIPTION
This is a "Follow best practices" pull request, that builds on top of #40 

It is not recommended to have `using namespace std;` on headers (see for details: https://stackoverflow.com/a/1452759/446149). Basically your users may not want to bring all of the std namespace, and it is not fair to enforce that. I've seen issues at 

This pull request does not remove `using namespace std;` from headers (yet), but rather adds that instruction to all compilation units (.cc files). Later, there will be a pull request that does the removal of that instruction from the headers.

I did not want to break festival in this PR, that's why I did not remove the `using namespace std;` here