### PR TITLE
walloc: fix size type from int => size_t

### DIFF
--- a/include/EST_walloc.h
+++ b/include/EST_walloc.h
@@ -38,14 +38,15 @@
 /*=======================================================================*/
 
 #if !defined(__EST_WALLOC_H__)
+#include <stddef.h>
 
 #if defined(__cplusplus)
 extern "C" {
 #endif
 
-void *safe_walloc(int size);
-void *safe_wcalloc(int size);
-void *safe_wrealloc(void *ptr, int size);
+void *safe_walloc(size_t size);
+void *safe_wcalloc(size_t size);
+void *safe_wrealloc(void *ptr, size_t size);
 #define walloc(TYPE,SIZE) ((TYPE *)safe_walloc(sizeof(TYPE)*(SIZE)))
 #define wcalloc(TYPE,SIZE) ((TYPE *)safe_wcalloc(sizeof(TYPE)*(SIZE)))
 #define wrealloc(PTR,TYPE,SIZE) ((TYPE *)safe_wrealloc((void *)(PTR), sizeof(TYPE)*(SIZE)))

--- a/utils/walloc.c
+++ b/utils/walloc.c
@@ -51,15 +51,15 @@
 /* use the debug malloc in flite */
 #include "cst_alloc.h"
 
-void *safe_walloc(int size)
+void *safe_walloc(size_t size)
 {
     return cst_safe_alloc(size);
 }
-void *safe_wrealloc(void *ptr, int size)
+void *safe_wrealloc(void *ptr, size_t size)
 {
     return cst_safe_realloc(ptr,size);
 }
-void *safe_wcalloc(int size)
+void *safe_wcalloc(size_t size)
 {
     return cst_safe_calloc(size);
 }
@@ -81,7 +81,7 @@ void debug_memory_summary(void)
 }
 
 #else
-void *safe_walloc(int size)
+void *safe_walloc(size_t size)
 {
     char *p;
     
@@ -103,7 +103,7 @@ void *safe_walloc(int size)
     return p;
 }
 
-void *safe_wrealloc(void *ptr, int size)
+void *safe_wrealloc(void *ptr, size_t size)
 {
     char *p;
 
@@ -127,7 +127,7 @@ void *safe_wrealloc(void *ptr, int size)
     return p;
 }
 
-void *safe_wcalloc(int size)
+void *safe_wcalloc(size_t size)
 {
     char *p = safe_walloc(size);
 


### PR DESCRIPTION
The typde size_t is used for most moderm implementations of `malloc`, `calloc`, `realloc`, etc.

Using just signed types like `int` leads to issues on 32-bit systems, if there are really large chunks of memory used such as e.g. for a chunk of 3.2 GB in Festival:

```
Building clunits/ldom index
WALLOC: failed to malloc -1094967296 bytes
```

Also, the macros `walloc()`. `wcalloc()` & `wrealloc()` use `sizeof()`, which itself returns `size_t` and not  `int`.

Compiling speech-tools and Festival with these changes, at least compiles on my Mac just fine. Unfortunately, there is no current CI pipeline active in this project for verification & tests.